### PR TITLE
Fix image/file drag-and-drop into terminal panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 2026-02-22 — Initial Release
+## 0.1.3 — 2026-02-23
+
+### Bug Fixes
+- Fix file/image drag-and-drop into terminal panes. Tauri v2 intercepts native drag events by default, preventing files from reaching the terminal. Now listens for Tauri's drag-drop events and pastes file paths through xterm.js with proper bracketed paste handling, so coding agents (OpenCode, Claude Code) correctly detect dropped images.
+- Added drag-over visual feedback (dashed blue border overlay) when hovering a file over a terminal pane.
+
+## 0.1.2 — 2026-02-22 — Initial Release
 
 ### Core Infrastructure
 - Tauri v2 scaffold with React + TypeScript + Vite frontend

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "beehive",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beehive",
-      "version": "0.1.0",
+      "version": "0.1.2",
+      "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",
@@ -58,6 +59,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1461,6 +1463,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1524,7 +1527,8 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
@@ -1559,6 +1563,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1817,6 +1822,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1858,6 +1864,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2023,6 +2030,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beehive",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Orchestrate coding agents across isolated git workspaces",
   "license": "MIT",
   "author": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -227,7 +227,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "beehive"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "dirs",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beehive"
-version = "0.1.2"
+version = "0.1.3"
 description = "Orchestrate coding agents across isolated git workspaces"
 authors = ["Mykyta Storozhenko <storozhenkomykyta@gmail.com>"]
 repository = "https://github.com/storozhenko98/beehive"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Beehive",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "identifier": "com.beehive.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.css
+++ b/src/App.css
@@ -1065,6 +1065,25 @@ select option {
 .pane-body {
   flex: 1;
   overflow: hidden;
+  position: relative;
+}
+
+/* ---- Drag-drop overlay ---- */
+
+.drop-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(137, 180, 250, 0.12);
+  border: 2px dashed var(--accent);
+  border-radius: 4px;
+  z-index: 10;
+  pointer-events: none;
+  font-size: 13px;
+  color: var(--accent);
+  letter-spacing: 0.3px;
 }
 
 /* ---- Settings screen ---- */

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
@@ -6,6 +6,11 @@ import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import "@xterm/xterm/css/xterm.css";
+
+interface DragDropPayload {
+  paths: string[];
+  position: { x: number; y: number };
+}
 
 interface TerminalPaneProps {
   id: string;
@@ -22,6 +27,13 @@ export function TerminalPane({ id, cwd, cmd, args, isVisible, onExit }: Terminal
   const fitAddonRef = useRef<FitAddon | null>(null);
   // Track which PTY session is "ours" to ignore stale exit events
   const activeSessionRef = useRef<string | null>(null);
+  // Drag-drop visual feedback (ref avoids stale closures in event callbacks)
+  const [isDragOver, setIsDragOver] = useState(false);
+  const isDragOverRef = useRef(false);
+  function updateDragOver(value: boolean) {
+    isDragOverRef.current = value;
+    setIsDragOver(value);
+  }
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -120,11 +132,48 @@ export function TerminalPane({ id, cwd, cmd, args, isVisible, onExit }: Terminal
     });
     resizeObserver.observe(containerRef.current);
 
+    // --- Drag-drop: listen for Tauri's global drag events ---
+    // Hit-test helper: check if window-relative position falls inside this pane
+    function isOverThisPane(x: number, y: number): boolean {
+      const el = document.elementFromPoint(x, y);
+      return !!containerRef.current && containerRef.current.contains(el);
+    }
+
+    const unlistenDragOver = listen<DragDropPayload>("tauri://drag-over", (event) => {
+      const { x, y } = event.payload.position;
+      const over = isOverThisPane(x, y);
+      if (over !== isDragOverRef.current) {
+        updateDragOver(over);
+      }
+    });
+
+    const unlistenDrop = listen<DragDropPayload>("tauri://drag-drop", (event) => {
+      updateDragOver(false);
+
+      const { paths, position } = event.payload;
+      if (!isOverThisPane(position.x, position.y)) return;
+      if (!terminalRef.current) return;
+      if (paths.length === 0) return;
+
+      // Paste the raw path(s) through xterm.js so bracketed paste mode
+      // is handled correctly. This mimics how real terminals (iTerm2, etc.)
+      // handle file drops — the running application (OpenCode, Claude Code)
+      // receives a paste event and can detect the file path as an image.
+      terminalRef.current.paste(paths.join(" "));
+    });
+
+    const unlistenDragLeave = listen("tauri://drag-leave", () => {
+      updateDragOver(false);
+    });
+
     return () => {
       resizeObserver.disconnect();
       onDataDisposable.dispose();
       unlistenOutput.then((fn) => fn());
       unlistenExit.then((fn) => fn());
+      unlistenDragOver.then((fn) => fn());
+      unlistenDrop.then((fn) => fn());
+      unlistenDragLeave.then((fn) => fn());
       invoke("close_pty", { id: sessionId }).catch(() => {});
       terminal.dispose();
       terminalRef.current = null;
@@ -153,7 +202,9 @@ export function TerminalPane({ id, cwd, cmd, args, isVisible, onExit }: Terminal
   return (
     <div
       ref={containerRef}
-      style={{ width: "100%", height: "100%", padding: "4px" }}
-    />
+      style={{ width: "100%", height: "100%", padding: "4px", position: "relative" }}
+    >
+      {isDragOver && <div className="drop-overlay">Drop file to paste path</div>}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- Fix file/image drag-and-drop into terminal panes so coding agents (OpenCode, Claude Code) correctly detect dropped images as `[Image 1]`
- Tauri v2 intercepts native drag events by default, preventing drops from reaching xterm.js. Now listens for Tauri's drag-drop events and pastes file paths through `terminal.paste()` with proper bracketed paste handling
- Added drag-over visual feedback (dashed blue border overlay) when hovering a file over a terminal pane

## Changes

| File | What |
|------|------|
| `src/components/TerminalPane.tsx` | Listen for `tauri://drag-over`, `tauri://drag-drop`, `tauri://drag-leave` events; hit-test via `elementFromPoint` to route to correct pane; paste paths through xterm.js |
| `src/App.css` | Drop overlay styles (dashed blue border, semi-transparent bg) |
| `CHANGELOG.md` | Added 0.1.3 entry |
| `package.json`, `Cargo.toml`, `tauri.conf.json` | Version bump to 0.1.3 |

## Testing

1. Open a hive, create a comb, open a terminal pane
2. Start OpenCode or Claude Code in the terminal
3. Drag an image from Finder onto the terminal pane
4. Agent should detect the image and show `[Image 1]`
5. Verify drag-over shows blue dashed overlay, and it disappears on drop or drag-away