### PR TITLE
Add Linux release and install support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,3 +83,69 @@ jobs:
         run: |
           cp cli/target/aarch64-apple-darwin/release/beehive-tui beehive-tui-darwin-arm64
           gh release upload "${GITHUB_REF_NAME}" beehive-tui-darwin-arm64 --clobber || true
+
+  build-linux:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: npm
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            src-tauri
+            cli
+
+      - name: Install Linux system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            curl \
+            file \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libxdo-dev \
+            patchelf \
+            wget
+
+      - name: Build CLI
+        run: cd cli && cargo build --release --target x86_64-unknown-linux-gnu
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build and release
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          tagName: v__VERSION__
+          releaseName: Beehive v__VERSION__
+          releaseDraft: false
+          args: --target x86_64-unknown-linux-gnu --bundles appimage,deb
+
+      - name: Upload CLI binary
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cp cli/target/x86_64-unknown-linux-gnu/release/beehive-tui beehive-tui-linux-x64
+          gh release upload "${GITHUB_REF_NAME}" beehive-tui-linux-x64 --clobber || true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,11 @@ The GitHub CLI must be authenticated: `gh auth login`
 
 - Xcode Command Line Tools: `xcode-select --install`
 
-> **Linux & Windows:** Beehive currently only supports macOS. Tauri v2 supports all three platforms, so porting should be feasible. If you'd like to help, see [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/) for platform-specific requirements. PRs for Linux/Windows support are very welcome.
+### Linux
+
+- Install Tauri system dependencies for your distro: [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/)
+
+> **Windows:** Beehive does not support Windows yet. PRs are welcome.
 
 ### Getting started
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Beehive lets you manage multiple repos, create isolated workspace clones on diff
 
 ## Install
 
-### Desktop App (macOS)
+### Desktop App (macOS / Linux)
 
-Download the latest `.dmg` from [Releases](https://github.com/storozhenko98/beehive/releases/latest). Signed and notarized for Apple Silicon.
+Download the latest desktop build from [Releases](https://github.com/storozhenko98/beehive/releases/latest): `.dmg` for macOS Apple Silicon, plus `.AppImage` and `.deb` for Linux x64.
 
 ### TUI
 
@@ -61,8 +61,6 @@ You'll be asked to choose `bh` or `beehive` as your command name. Auto-updates o
 ```bash
 gh auth login   # Required — Beehive uses gh for repo operations
 ```
-
-> **Note:** macOS only for now. Linux and Windows support is planned — contributions welcome.
 
 ## Building from Source
 
@@ -155,7 +153,7 @@ The GUI and TUI share the same config and data — you can use both interchangea
 |----------|-----|-----|
 | **macOS** (Apple Silicon) | Signed & notarized | Supported |
 | **macOS** (Intel) | Should work (untested) | Should work (untested) |
-| **Linux** | Not yet | Not yet |
+| **Linux** (x64) | Supported | Supported |
 | **Windows** | Not yet | Not yet |
 
 ## Contributing

--- a/cli/src/update.rs
+++ b/cli/src/update.rs
@@ -6,6 +6,17 @@ const REPO: &str = "storozhenko98/beehive";
 const INSTALL_CMD: &str =
     "curl -fsSL https://raw.githubusercontent.com/storozhenko98/beehive/main/install.sh | bash";
 
+fn release_asset_name() -> Result<&'static str, String> {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("macos", "aarch64") => Ok("beehive-tui-darwin-arm64"),
+        ("linux", "x86_64") => Ok("beehive-tui-linux-x64"),
+        (os, arch) => Err(format!(
+            "Self-update is not supported on {} {} yet. Update manually:\n  {}",
+            os, arch, INSTALL_CMD
+        )),
+    }
+}
+
 /// Check GitHub for a newer release. Returns `Some(version)` if an update is available.
 pub fn check_for_update() -> Option<String> {
     let output = run_cmd(
@@ -33,7 +44,7 @@ pub fn check_for_update() -> Option<String> {
 /// or Err with a user-friendly message (including the manual install command).
 pub fn self_update(version: &str) -> Result<(), String> {
     let tag = format!("v{}", version);
-    let asset = "beehive-tui-darwin-arm64";
+    let asset = release_asset_name()?;
     let url = format!(
         "https://github.com/{}/releases/download/{}/{}",
         REPO, tag, asset

--- a/install.sh
+++ b/install.sh
@@ -11,19 +11,30 @@ ARCH="$(uname -m)"
 
 case "$OS" in
   Darwin) OS_LABEL="darwin" ;;
+  Linux) OS_LABEL="linux" ;;
   *)
-    echo "Error: Unsupported OS: $OS (only macOS is supported currently)"
+    echo "Error: Unsupported OS: $OS (supported: macOS Apple Silicon, Linux x64)"
     exit 1
     ;;
 esac
 
-case "$ARCH" in
-  arm64|aarch64) ARCH_LABEL="arm64" ;;
-  *)
-    echo "Error: Unsupported architecture: $ARCH (only Apple Silicon is supported currently)"
-    exit 1
-    ;;
-esac
+if [ "$OS_LABEL" = "darwin" ]; then
+  case "$ARCH" in
+    arm64|aarch64) ARCH_LABEL="arm64" ;;
+    *)
+      echo "Error: Unsupported architecture: $ARCH (macOS builds currently support Apple Silicon only)"
+      exit 1
+      ;;
+  esac
+else
+  case "$ARCH" in
+    x86_64|amd64) ARCH_LABEL="x64" ;;
+    *)
+      echo "Error: Unsupported architecture: $ARCH (Linux builds currently support x64 only)"
+      exit 1
+      ;;
+  esac
+fi
 
 ASSET_NAME="${BINARY_NAME}-${OS_LABEL}-${ARCH_LABEL}"
 

--- a/src-tauri/src/hive.rs
+++ b/src-tauri/src/hive.rs
@@ -1,8 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
-
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -140,7 +139,9 @@ pub async fn preflight_check() -> Result<PreflightResult, String> {
         }
         Err(_) => {
             result.ok = false;
-            result.messages.push("git is not installed. Install it from https://git-scm.com".to_string());
+            result
+                .messages
+                .push("git is not installed. Install it from https://git-scm.com".to_string());
         }
     }
 
@@ -153,7 +154,9 @@ pub async fn preflight_check() -> Result<PreflightResult, String> {
         }
         Err(_) => {
             result.ok = false;
-            result.messages.push("gh CLI is not installed. Install it from https://cli.github.com".to_string());
+            result.messages.push(
+                "gh CLI is not installed. Install it from https://cli.github.com".to_string(),
+            );
         }
     }
 
@@ -166,7 +169,9 @@ pub async fn preflight_check() -> Result<PreflightResult, String> {
             }
             Err(_) => {
                 result.ok = false;
-                result.messages.push("gh is not authenticated. Run: gh auth login".to_string());
+                result
+                    .messages
+                    .push("gh is not authenticated. Run: gh auth login".to_string());
             }
         }
     }
@@ -201,10 +206,13 @@ pub async fn get_home_dir() -> Result<String, String> {
 pub async fn load_app_config() -> Result<AppConfig, String> {
     let path = app_config_path();
     if !path.exists() {
-        return Ok(AppConfig { beehive_dir: None, cli_command: None });
+        return Ok(AppConfig {
+            beehive_dir: None,
+            cli_command: None,
+        });
     }
-    let data = fs::read_to_string(&path)
-        .map_err(|e| format!("Failed to read app config: {}", e))?;
+    let data =
+        fs::read_to_string(&path).map_err(|e| format!("Failed to read app config: {}", e))?;
     serde_json::from_str(&data).map_err(|e| format!("Failed to parse app config: {}", e))
 }
 
@@ -212,11 +220,10 @@ pub async fn load_app_config() -> Result<AppConfig, String> {
 pub async fn save_app_config(config: AppConfig) -> Result<(), String> {
     let path = app_config_path();
     if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .map_err(|e| format!("Failed to create ~/.beehive: {}", e))?;
+        fs::create_dir_all(parent).map_err(|e| format!("Failed to create ~/.beehive: {}", e))?;
     }
-    let json = serde_json::to_string_pretty(&config)
-        .map_err(|e| format!("Failed to serialize: {}", e))?;
+    let json =
+        serde_json::to_string_pretty(&config).map_err(|e| format!("Failed to serialize: {}", e))?;
     fs::write(&path, json).map_err(|e| format!("Failed to write app config: {}", e))
 }
 
@@ -260,9 +267,7 @@ fn list_dir_entries(dir: &std::path::Path) -> Result<Vec<DirEntry>, String> {
 
     let mut results: Vec<DirEntry> = entries
         .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.file_type().map(|ft| ft.is_dir()).unwrap_or(false)
-        })
+        .filter(|e| e.file_type().map(|ft| ft.is_dir()).unwrap_or(false))
         .filter(|e| {
             // Hide hidden dirs unless parent is home
             let name = e.file_name().to_string_lossy().to_string();
@@ -303,8 +308,8 @@ pub async fn load_beehive(dir: String) -> Result<BeehiveConfig, String> {
     if !config_path.exists() {
         return Err("No beehive.json found".to_string());
     }
-    let data = fs::read_to_string(&config_path)
-        .map_err(|e| format!("Failed to read config: {}", e))?;
+    let data =
+        fs::read_to_string(&config_path).map_err(|e| format!("Failed to read config: {}", e))?;
     serde_json::from_str(&data).map_err(|e| format!("Failed to parse config: {}", e))
 }
 
@@ -314,8 +319,17 @@ pub async fn verify_repo(repo_url: String) -> Result<HiveInfo, String> {
 
     // Use gh to get repo info
     let repo_spec = format!("{}/{}", owner, repo_name);
-    let json_output = run_cmd("gh", &["repo", "view", &repo_spec, "--json", "name,owner,description,defaultBranchRef,sshUrl,url"])
-        .map_err(|e| format!("Cannot access repo '{}': {}", repo_spec, e))?;
+    let json_output = run_cmd(
+        "gh",
+        &[
+            "repo",
+            "view",
+            &repo_spec,
+            "--json",
+            "name,owner,description,defaultBranchRef,sshUrl,url",
+        ],
+    )
+    .map_err(|e| format!("Cannot access repo '{}': {}", repo_spec, e))?;
 
     let parsed: serde_json::Value = serde_json::from_str(&json_output)
         .map_err(|e| format!("Failed to parse gh output: {}", e))?;
@@ -341,11 +355,12 @@ pub async fn verify_repo(repo_url: String) -> Result<HiveInfo, String> {
     };
 
     // Verify the repo is actually cloneable with git ls-remote
-    run_cmd("git", &["ls-remote", "--heads", &clone_url])
-        .map_err(|e| format!(
+    run_cmd("git", &["ls-remote", "--heads", &clone_url]).map_err(|e| {
+        format!(
             "Repository '{}' is not accessible via git. Check your SSH keys or credentials.\n{}",
             repo_spec, e
-        ))?;
+        )
+    })?;
 
     let dir_name = format!("repo_{}", repo_name);
 
@@ -389,8 +404,8 @@ pub async fn create_hive(beehive_dir: String, repo_url: String) -> Result<HiveIn
         info: info.clone(),
         combs: vec![],
     };
-    let state_json = serde_json::to_string_pretty(&state)
-        .map_err(|e| format!("Failed to serialize: {}", e))?;
+    let state_json =
+        serde_json::to_string_pretty(&state).map_err(|e| format!("Failed to serialize: {}", e))?;
 
     if let Err(e) = fs::write(dot_hive.join("state.json"), &state_json) {
         // Clean up on failure
@@ -457,18 +472,29 @@ pub async fn delete_hive(beehive_dir: String, dir_name: String) -> Result<(), St
 }
 
 #[tauri::command]
-pub async fn list_branches(beehive_dir: String, dir_name: String) -> Result<Vec<RepoBranch>, String> {
+pub async fn list_branches(
+    beehive_dir: String,
+    dir_name: String,
+) -> Result<Vec<RepoBranch>, String> {
     let state = load_hive_state(&beehive_dir, &dir_name)?;
     let repo_spec = format!("{}/{}", state.info.owner, state.info.repo_name);
 
-    let output = run_cmd("gh", &[
-        "api",
-        &format!("repos/{}/branches?per_page=100", repo_spec),
-        "--paginate",
-        "--jq", ".[].name",
-    ]).map_err(|e| format!("Failed to list branches: {}", e))?;
+    let output = run_cmd(
+        "gh",
+        &[
+            "api",
+            &format!("repos/{}/branches?per_page=100", repo_spec),
+            "--paginate",
+            "--jq",
+            ".[].name",
+        ],
+    )
+    .map_err(|e| format!("Failed to list branches: {}", e))?;
 
-    let default_branch = state.info.default_branch.unwrap_or_else(|| "main".to_string());
+    let default_branch = state
+        .info
+        .default_branch
+        .unwrap_or_else(|| "main".to_string());
 
     let branches: Vec<RepoBranch> = output
         .lines()
@@ -695,8 +721,13 @@ fn validate_comb_name(name: &str, existing_combs: &[Comb]) -> Result<(), String>
     if name.starts_with('.') || name.starts_with('-') {
         return Err("Comb name cannot start with '.' or '-'".to_string());
     }
-    if !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-') {
-        return Err("Comb name can only contain letters, numbers, hyphens, and underscores".to_string());
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return Err(
+            "Comb name can only contain letters, numbers, hyphens, and underscores".to_string(),
+        );
     }
     if name == ".hive" {
         return Err("'.hive' is a reserved name".to_string());
@@ -708,8 +739,7 @@ fn validate_comb_name(name: &str, existing_combs: &[Comb]) -> Result<(), String>
 }
 
 fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), String> {
-    fs::create_dir_all(dst)
-        .map_err(|e| format!("Failed to create directory {:?}: {}", dst, e))?;
+    fs::create_dir_all(dst).map_err(|e| format!("Failed to create directory {:?}: {}", dst, e))?;
     for entry in fs::read_dir(src).map_err(|e| format!("Failed to read {:?}: {}", src, e))? {
         let entry = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
         let src_path = entry.path();
@@ -747,7 +777,10 @@ pub async fn copy_comb(
     let new_dir = hive_dir.join(&new_name);
 
     if !source_dir.exists() {
-        return Err(format!("Source comb directory does not exist: {}", source.path));
+        return Err(format!(
+            "Source comb directory does not exist: {}",
+            source.path
+        ));
     }
 
     copy_dir_recursive(source_dir, &new_dir)?;
@@ -776,6 +809,38 @@ pub struct CliStatusResult {
     pub path: Option<String>,
 }
 
+fn cli_release_asset_name() -> Result<&'static str, String> {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("macos", "aarch64") => Ok("beehive-tui-darwin-arm64"),
+        ("linux", "x86_64") => Ok("beehive-tui-linux-x64"),
+        (os, arch) => Err(format!(
+            "CLI install is not supported on {} {} yet",
+            os, arch
+        )),
+    }
+}
+
+fn preferred_cli_bin_dir() -> Result<PathBuf, String> {
+    match std::env::consts::OS {
+        "macos" => Ok(PathBuf::from("/usr/local/bin")),
+        "linux" => dirs::home_dir()
+            .map(|home| home.join(".local/bin"))
+            .ok_or_else(|| "Could not determine home directory".to_string()),
+        os => Err(format!("CLI install is not supported on {} yet", os)),
+    }
+}
+
+fn cli_candidate_paths(cmd_name: &str) -> Result<Vec<PathBuf>, String> {
+    let mut paths = vec![preferred_cli_bin_dir()?.join(cmd_name)];
+    if std::env::consts::OS == "linux" {
+        let fallback = PathBuf::from("/usr/local/bin").join(cmd_name);
+        if !paths.contains(&fallback) {
+            paths.push(fallback);
+        }
+    }
+    Ok(paths)
+}
+
 #[tauri::command]
 pub async fn install_cli(cmd_name: String) -> Result<String, String> {
     // Validate command name
@@ -784,11 +849,13 @@ pub async fn install_cli(cmd_name: String) -> Result<String, String> {
     }
 
     let version = env!("CARGO_PKG_VERSION");
+    let asset = cli_release_asset_name()?;
     let url = format!(
-        "https://github.com/storozhenko98/beehive/releases/download/v{}/beehive-tui-darwin-arm64",
-        version
+        "https://github.com/storozhenko98/beehive/releases/download/v{}/{}",
+        version, asset
     );
-    let install_path = format!("/usr/local/bin/{}", cmd_name);
+    let install_dir = preferred_cli_bin_dir()?;
+    let install_path = install_dir.join(&cmd_name);
 
     // Download to temp file
     let tmp = std::env::temp_dir().join("beehive-cli-install");
@@ -800,7 +867,10 @@ pub async fn install_cli(cmd_name: String) -> Result<String, String> {
     if !output.status.success() {
         return Err(format!(
             "Download failed: {}",
-            String::from_utf8_lossy(&output.stderr).lines().next().unwrap_or("unknown error")
+            String::from_utf8_lossy(&output.stderr)
+                .lines()
+                .next()
+                .unwrap_or("unknown error")
         ));
     }
 
@@ -811,24 +881,27 @@ pub async fn install_cli(cmd_name: String) -> Result<String, String> {
         let _ = fs::set_permissions(&tmp, fs::Permissions::from_mode(0o755));
     }
 
-    // Ensure /usr/local/bin exists
-    let parent = Path::new("/usr/local/bin");
-    if !parent.exists() {
-        fs::create_dir_all(parent)
-            .map_err(|e| format!("Failed to create /usr/local/bin: {}", e))?;
+    // Ensure install dir exists
+    if !install_dir.exists() {
+        fs::create_dir_all(&install_dir)
+            .map_err(|e| format!("Failed to create {}: {}", install_dir.display(), e))?;
     }
 
     // Remove any existing file at the target path
-    let dest = Path::new(&install_path);
-    if dest.exists() || dest.symlink_metadata().is_ok() {
-        fs::remove_file(dest)
-            .map_err(|e| format!("Failed to remove existing {}: {}. Try: sudo rm {}", install_path, e, install_path))?;
+    if install_path.exists() || install_path.symlink_metadata().is_ok() {
+        fs::remove_file(&install_path).map_err(|e| {
+            format!(
+                "Failed to remove existing {}: {}",
+                install_path.display(),
+                e
+            )
+        })?;
     }
 
     // Move binary into place
     fs::rename(&tmp, &install_path)
         .or_else(|_| fs::copy(&tmp, &install_path).map(|_| ()))
-        .map_err(|e| format!("Failed to install to {}: {}. Check permissions.", install_path, e))?;
+        .map_err(|e| format!("Failed to install to {}: {}", install_path.display(), e))?;
     let _ = fs::remove_file(&tmp);
 
     // Save command name preference to config
@@ -836,7 +909,7 @@ pub async fn install_cli(cmd_name: String) -> Result<String, String> {
     config.cli_command = Some(cmd_name.clone());
     save_app_config(config).await?;
 
-    Ok(install_path)
+    Ok(install_path.to_string_lossy().to_string())
 }
 
 #[tauri::command]
@@ -846,23 +919,27 @@ pub async fn uninstall_cli() -> Result<(), String> {
     let mut removed = false;
 
     if let Some(ref name) = config.cli_command {
-        let path = format!("/usr/local/bin/{}", name);
-        let p = Path::new(&path);
-        if p.exists() {
-            fs::remove_file(p)
-                .map_err(|e| format!("Failed to remove {}: {}. Try: sudo rm {}", path, e, path))?;
-            removed = true;
+        for path in cli_candidate_paths(name)? {
+            if path.exists() {
+                fs::remove_file(&path)
+                    .map_err(|e| format!("Failed to remove {}: {}", path.display(), e))?;
+                removed = true;
+            }
         }
     }
 
     // Also check the other name as fallback
     if !removed {
         for name in &["bh", "beehive"] {
-            let path = format!("/usr/local/bin/{}", name);
-            let p = Path::new(&path);
-            if p.exists() {
-                fs::remove_file(p)
-                    .map_err(|e| format!("Failed to remove {}: {}. Try: sudo rm {}", path, e, path))?;
+            for path in cli_candidate_paths(name)? {
+                if path.exists() {
+                    fs::remove_file(&path)
+                        .map_err(|e| format!("Failed to remove {}: {}", path.display(), e))?;
+                    removed = true;
+                    break;
+                }
+            }
+            if removed {
                 break;
             }
         }
@@ -882,25 +959,27 @@ pub async fn cli_status() -> Result<CliStatusResult, String> {
 
     // Check config preference first
     if let Some(ref name) = config.cli_command {
-        let path = format!("/usr/local/bin/{}", name);
-        if Path::new(&path).exists() {
-            return Ok(CliStatusResult {
-                installed: true,
-                cmd_name: Some(name.clone()),
-                path: Some(path),
-            });
+        for path in cli_candidate_paths(name)? {
+            if path.exists() {
+                return Ok(CliStatusResult {
+                    installed: true,
+                    cmd_name: Some(name.clone()),
+                    path: Some(path.to_string_lossy().to_string()),
+                });
+            }
         }
     }
 
     // Fallback: check both names
     for name in &["bh", "beehive"] {
-        let path = format!("/usr/local/bin/{}", name);
-        if Path::new(&path).exists() {
-            return Ok(CliStatusResult {
-                installed: true,
-                cmd_name: Some(name.to_string()),
-                path: Some(path),
-            });
+        for path in cli_candidate_paths(name)? {
+            if path.exists() {
+                return Ok(CliStatusResult {
+                    installed: true,
+                    cmd_name: Some(name.to_string()),
+                    path: Some(path.to_string_lossy().to_string()),
+                });
+            }
         }
     }
 
@@ -918,29 +997,36 @@ fn parse_repo_url(url: &str) -> Result<(String, String), String> {
     //         https://github.com/owner/repo.git
     //         https://github.com/owner/repo
     //         owner/repo
-    let cleaned = url
-        .trim()
-        .trim_end_matches('/')
-        .trim_end_matches(".git");
+    let cleaned = url.trim().trim_end_matches('/').trim_end_matches(".git");
 
     let (owner, repo_name) = if cleaned.contains(':') && cleaned.starts_with("git@") {
         // SSH format: git@github.com:owner/repo
-        let after_colon = cleaned.split(':').last()
-            .ok_or("Invalid SSH URL format")?;
+        let after_colon = cleaned.split(':').last().ok_or("Invalid SSH URL format")?;
         let parts: Vec<&str> = after_colon.split('/').collect();
         if parts.len() >= 2 {
-            (parts[parts.len() - 2].to_string(), parts[parts.len() - 1].to_string())
+            (
+                parts[parts.len() - 2].to_string(),
+                parts[parts.len() - 1].to_string(),
+            )
         } else {
-            return Err(format!("Cannot parse SSH URL: {}. Expected format: git@github.com:owner/repo", url));
+            return Err(format!(
+                "Cannot parse SSH URL: {}. Expected format: git@github.com:owner/repo",
+                url
+            ));
         }
     } else if cleaned.contains("github.com/") {
-        let after_gh = cleaned.split("github.com/").last()
+        let after_gh = cleaned
+            .split("github.com/")
+            .last()
             .ok_or("Invalid GitHub URL")?;
         let parts: Vec<&str> = after_gh.split('/').collect();
         if parts.len() >= 2 {
             (parts[0].to_string(), parts[1].to_string())
         } else {
-            return Err(format!("Cannot parse GitHub URL: {}. Expected format: https://github.com/owner/repo", url));
+            return Err(format!(
+                "Cannot parse GitHub URL: {}. Expected format: https://github.com/owner/repo",
+                url
+            ));
         }
     } else {
         // Try owner/repo format
@@ -948,7 +1034,10 @@ fn parse_repo_url(url: &str) -> Result<(String, String), String> {
         if parts.len() == 2 {
             (parts[0].to_string(), parts[1].to_string())
         } else {
-            return Err(format!("Cannot parse '{}'. Use owner/repo, a GitHub URL, or SSH URL.", url));
+            return Err(format!(
+                "Cannot parse '{}'. Use owner/repo, a GitHub URL, or SSH URL.",
+                url
+            ));
         }
     };
 
@@ -968,8 +1057,8 @@ fn load_hive_state(beehive_dir: &str, dir_name: &str) -> Result<HiveState, Strin
         .join(dir_name)
         .join(".hive")
         .join("state.json");
-    let data = fs::read_to_string(&state_path)
-        .map_err(|e| format!("Failed to read hive state: {}", e))?;
+    let data =
+        fs::read_to_string(&state_path).map_err(|e| format!("Failed to read hive state: {}", e))?;
     serde_json::from_str(&data).map_err(|e| format!("Failed to parse hive state: {}", e))
 }
 
@@ -978,8 +1067,8 @@ fn save_hive_state(beehive_dir: &str, dir_name: &str, state: &HiveState) -> Resu
         .join(dir_name)
         .join(".hive")
         .join("state.json");
-    let json = serde_json::to_string_pretty(state)
-        .map_err(|e| format!("Failed to serialize: {}", e))?;
+    let json =
+        serde_json::to_string_pretty(state).map_err(|e| format!("Failed to serialize: {}", e))?;
     fs::write(&state_path, json).map_err(|e| format!("Failed to write state: {}", e))
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,6 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["app", "dmg"],
     "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,5 @@
+{
+  "bundle": {
+    "targets": ["appimage", "deb"]
+  }
+}

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,5 @@
+{
+  "bundle": {
+    "targets": ["app", "dmg"]
+  }
+}

--- a/src/components/SettingsScreen.tsx
+++ b/src/components/SettingsScreen.tsx
@@ -298,7 +298,7 @@ export function SettingsScreen({ beehiveDir, onBack, onReset, backLabel }: Props
                   beehive
                 </button>
                 <span style={{ color: "var(--text-muted)", fontSize: 11, alignSelf: "center" }}>
-                  installed as /usr/local/bin/{cliChoice}
+                  installs to /usr/local/bin on macOS or ~/.local/bin on Linux
                 </span>
               </div>
               <button

--- a/web/public/install.sh
+++ b/web/public/install.sh
@@ -11,19 +11,30 @@ ARCH="$(uname -m)"
 
 case "$OS" in
   Darwin) OS_LABEL="darwin" ;;
+  Linux) OS_LABEL="linux" ;;
   *)
-    echo "Error: Unsupported OS: $OS (only macOS is supported currently)"
+    echo "Error: Unsupported OS: $OS (supported: macOS Apple Silicon, Linux x64)"
     exit 1
     ;;
 esac
 
-case "$ARCH" in
-  arm64|aarch64) ARCH_LABEL="arm64" ;;
-  *)
-    echo "Error: Unsupported architecture: $ARCH (only Apple Silicon is supported currently)"
-    exit 1
-    ;;
-esac
+if [ "$OS_LABEL" = "darwin" ]; then
+  case "$ARCH" in
+    arm64|aarch64) ARCH_LABEL="arm64" ;;
+    *)
+      echo "Error: Unsupported architecture: $ARCH (macOS builds currently support Apple Silicon only)"
+      exit 1
+      ;;
+  esac
+else
+  case "$ARCH" in
+    x86_64|amd64) ARCH_LABEL="x64" ;;
+    *)
+      echo "Error: Unsupported architecture: $ARCH (Linux builds currently support x64 only)"
+      exit 1
+      ;;
+  esac
+fi
 
 ASSET_NAME="${BINARY_NAME}-${OS_LABEL}-${ARCH_LABEL}"
 

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -53,6 +53,7 @@ export const metadata: Metadata = {
     "Claude Code",
     "developer tools",
     "macOS",
+    "Linux",
   ],
   authors: [{ name: "Mykyta Storozhenko", url: "https://storozh.dev" }],
 };

--- a/web/src/app/opengraph-image.tsx
+++ b/web/src/app/opengraph-image.tsx
@@ -80,7 +80,7 @@ export default async function OGImage() {
             marginTop: 40,
           }}
         >
-          {["macOS", "GUI + TUI", "Open Source"].map((label) => (
+          {["macOS + Linux", "GUI + TUI", "Open Source"].map((label) => (
             <div
               key={label}
               style={{

--- a/web/src/app/twitter-image.tsx
+++ b/web/src/app/twitter-image.tsx
@@ -77,7 +77,7 @@ export default async function TwitterImage() {
             marginTop: 40,
           }}
         >
-          {["macOS", "GUI + TUI", "Open Source"].map((label) => (
+          {["macOS + Linux", "GUI + TUI", "Open Source"].map((label) => (
             <div
               key={label}
               style={{

--- a/web/src/components/cli-section.tsx
+++ b/web/src/components/cli-section.tsx
@@ -19,7 +19,7 @@ export function CliSection() {
           command, no dependencies beyond git and gh. You&apos;ll be asked to
           choose <code className="font-mono text-ctp-text">bh</code> or{" "}
           <code className="font-mono text-ctp-text">beehive</code> as your
-          command name.
+          command name. Supports macOS Apple Silicon and Linux x64.
         </p>
         <div className="bg-ctp-mantle border border-ctp-surface0 rounded-lg p-3.5 px-4 overflow-x-auto">
           <code className="text-[13px] text-ctp-green whitespace-nowrap font-mono">

--- a/web/src/components/hero.tsx
+++ b/web/src/components/hero.tsx
@@ -37,7 +37,7 @@ export function Hero() {
           href="https://github.com/storozhenko98/beehive/releases/latest"
           className="inline-flex items-center gap-2 px-7 py-3.5 rounded-xl text-[15px] font-semibold bg-ctp-blue text-ctp-crust shadow-[0_0_20px_rgba(137,180,250,0.2),inset_0_1px_0_rgba(255,255,255,0.1)] hover:bg-ctp-sapphire hover:shadow-[0_0_30px_rgba(137,180,250,0.3)] hover:-translate-y-px transition-all"
         >
-          Download for macOS
+          Download Desktop App
         </a>
         <a
           href="https://github.com/storozhenko98/beehive"
@@ -61,9 +61,9 @@ export function Hero() {
 
       {/* Meta info */}
       <p className="text-[13px] text-ctp-overlay0">
-        <span>Apple Silicon</span>
+        <span>macOS (Apple Silicon) + Linux x64</span>
         <span className="before:content-['·'] before:mx-2 before:text-ctp-surface1">
-          Signed &amp; Notarized
+          Signed &amp; notarized on macOS
         </span>
         <span className="before:content-['·'] before:mx-2 before:text-ctp-surface1">
           GUI + TUI share config


### PR DESCRIPTION
## Summary
- add a Linux release build in GitHub Actions and split Tauri bundle targets by platform so releases can ship macOS and Linux desktop artifacts
- make CLI install and self-update choose the correct release asset on macOS vs Linux, including Linux install paths in the desktop app flow
- update install scripts, website copy, and docs to advertise Linux x64 support

## Verification
- source \"$HOME/.cargo/env\" && cargo test --manifest-path cli/Cargo.toml
- source \"$HOME/.cargo/env\" && cargo check --manifest-path cli/Cargo.toml
- source \"$HOME/.cargo/env\" && cargo check --manifest-path src-tauri/Cargo.toml
- npm ci && npx tsc --noEmit
- cd web && npm ci && npm run build