### PR TITLE
Add drag-and-drop reordering for combs in GUI sidebar

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beehive-tui"
-version = "0.1.98"
+version = "0.1.99"
 edition = "2021"
 
 [dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beehive",
-  "version": "0.1.98",
+  "version": "0.1.99",
   "description": "Orchestrate coding agents across isolated git workspaces",
   "license": "MIT",
   "author": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -236,7 +236,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "beehive"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "dirs",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beehive"
-version = "0.1.98"
+version = "0.1.99"
 description = "Orchestrate coding agents across isolated git workspaces"
 authors = ["Mykyta Storozhenko <storozhenkomykyta@gmail.com>"]
 repository = "https://github.com/storozhenko98/beehive"

--- a/src-tauri/src/hive.rs
+++ b/src-tauri/src/hive.rs
@@ -768,6 +768,26 @@ pub async fn copy_comb(
     Ok(comb)
 }
 
+#[tauri::command]
+pub async fn reorder_combs(
+    beehive_dir: String,
+    dir_name: String,
+    comb_ids: Vec<String>,
+) -> Result<(), String> {
+    let mut state = load_hive_state(&beehive_dir, &dir_name)?;
+
+    let mut ordered: Vec<Comb> = Vec::with_capacity(state.combs.len());
+    for id in &comb_ids {
+        if let Some(pos) = state.combs.iter().position(|c| c.id == *id) {
+            ordered.push(state.combs.remove(pos));
+        }
+    }
+    ordered.append(&mut state.combs);
+    state.combs = ordered;
+
+    save_hive_state(&beehive_dir, &dir_name, &state)
+}
+
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CliStatusResult {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,6 +45,7 @@ pub fn run() {
             hive::save_comb_panes,
             hive::get_comb_panes,
             hive::save_custom_buttons,
+            hive::reorder_combs,
             hive::install_cli,
             hive::uninstall_cli,
             hive::cli_status,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Beehive",
-  "version": "0.1.98",
+  "version": "0.1.99",
   "identifier": "com.beehive.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/App.css
+++ b/src/App.css
@@ -792,6 +792,25 @@ select option {
   50% { opacity: 1; }
 }
 
+/* The grabbed item lifts up */
+.sidebar-comb-item.dragging {
+  position: relative;
+  z-index: 10;
+  background: var(--bg-surface);
+  border-left-color: var(--accent);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(137, 180, 250, 0.3);
+  scale: 1.02;
+}
+
+/* Disable hover and dim non-dragged items while dragging */
+.sidebar-comb-list.is-dragging .sidebar-comb-item:not(.dragging) {
+  opacity: 0.7;
+}
+
+.sidebar-comb-list.is-dragging .sidebar-comb-item:hover {
+  background: none;
+}
+
 .sidebar-empty {
   padding: 12px 16px;
   color: var(--text-muted);

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -287,6 +287,29 @@ export function MainLayout({ beehiveDir, onReset }: Props) {
     }
   }
 
+  const handleReorderCombs = useCallback(async (combIds: string[]) => {
+    if (!activeHiveDirName) return;
+    const hiveDirName = activeHiveDirName;
+
+    // Optimistic update
+    updateRuntime(hiveDirName, (rt) => {
+      const byId = new Map(rt.combs.map((c) => [c.id, c]));
+      const reordered = combIds.map((id) => byId.get(id)).filter(Boolean) as Comb[];
+      // Append any combs not in the list (safety)
+      const idSet = new Set(combIds);
+      for (const c of rt.combs) {
+        if (!idSet.has(c.id)) reordered.push(c);
+      }
+      return { ...rt, combs: reordered };
+    });
+
+    try {
+      await invoke("reorder_combs", { beehiveDir, dirName: hiveDirName, combIds });
+    } catch (e) {
+      console.error("Failed to reorder combs:", e);
+    }
+  }, [activeHiveDirName, beehiveDir]);
+
   async function saveCustomButtons(buttons: CustomButton[]) {
     if (!activeHiveDirName) return;
     try {
@@ -363,6 +386,7 @@ export function MainLayout({ beehiveDir, onReset }: Props) {
           setCopyCombLoading(false);
           setOverlay({ type: "copyComb", sourceCombId: combId });
         }}
+        onReorderCombs={handleReorderCombs}
       />
 
       <div className="main-content">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import type { HiveInfo, Comb } from "../types";
+import { useSortable } from "../hooks/useSortable";
 
 interface Props {
   hives: HiveInfo[];
@@ -14,6 +15,7 @@ interface Props {
   onHelp: () => void;
   onDeleteComb: (combId: string) => void;
   onCopyComb: (combId: string) => void;
+  onReorderCombs: (combIds: string[]) => void;
 }
 
 export function Sidebar({
@@ -29,12 +31,13 @@ export function Sidebar({
   onHelp,
   onDeleteComb,
   onCopyComb,
+  onReorderCombs,
 }: Props) {
   const [hiveDropdownOpen, setHiveDropdownOpen] = useState(false);
   const hiveDropdownRef = useRef<HTMLDivElement>(null);
-
-  // Delete confirmation: just track which combId is in "confirm" state
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+  const { isDragging, getItemProps } = useSortable(combs, onReorderCombs);
 
   // Close hive dropdown on outside click
   useEffect(() => {
@@ -90,66 +93,77 @@ export function Sidebar({
       {/* Comb list */}
       <div className="sidebar-section sidebar-combs">
         <div className="sidebar-section-label">Combs</div>
-        <div className="sidebar-comb-list">
-          {combs.map((comb) => (
-            <div
-              key={comb.id}
-              className={`sidebar-comb-item ${comb.id === activeCombId ? "active" : ""} ${comb.cloning ? "cloning" : ""}`}
-              onClick={() => !comb.cloning && onSelectComb(comb)}
-            >
-              <div className="sidebar-comb-info">
-                <span className="sidebar-comb-name">{comb.name}</span>
-                {comb.cloning ? (
-                  <span className="sidebar-comb-cloning">Cloning...</span>
-                ) : (
-                  <span className="sidebar-comb-branch">{comb.branch}</span>
+        <div className={`sidebar-comb-list ${isDragging ? "is-dragging" : ""}`}>
+          {combs.map((comb, idx) => {
+            const { ref, onPointerDown, style, isDragged } = getItemProps(idx);
+
+            return (
+              <div
+                key={comb.id}
+                ref={ref}
+                className={`sidebar-comb-item ${comb.id === activeCombId ? "active" : ""} ${comb.cloning ? "cloning" : ""} ${isDragged ? "dragging" : ""}`}
+                style={style}
+                onPointerDown={(e) => {
+                  if (!comb.cloning) onPointerDown(e);
+                }}
+                onClick={() => {
+                  if (!comb.cloning && !isDragging) onSelectComb(comb);
+                }}
+              >
+                <div className="sidebar-comb-info">
+                  <span className="sidebar-comb-name">{comb.name}</span>
+                  {comb.cloning ? (
+                    <span className="sidebar-comb-cloning">Cloning...</span>
+                  ) : (
+                    <span className="sidebar-comb-branch">{comb.branch}</span>
+                  )}
+                </div>
+                {!comb.cloning && (
+                  <>
+                    {confirmDeleteId === comb.id ? (
+                      <div className="delete-confirm-inline" onClick={(e) => e.stopPropagation()}>
+                        <button
+                          className="btn-sm btn-danger"
+                          onClick={() => {
+                            setConfirmDeleteId(null);
+                            onDeleteComb(comb.id);
+                          }}
+                        >
+                          Sure?
+                        </button>
+                        <button className="btn-sm" onClick={() => setConfirmDeleteId(null)}>
+                          No
+                        </button>
+                      </div>
+                    ) : (
+                      <div className="sidebar-comb-actions">
+                        <button
+                          className="sidebar-comb-copy"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onCopyComb(comb.id);
+                          }}
+                          title="Copy comb"
+                        >
+                          &#x2398;
+                        </button>
+                        <button
+                          className="sidebar-comb-delete"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setConfirmDeleteId(comb.id);
+                          }}
+                          title="Delete comb"
+                        >
+                          x
+                        </button>
+                      </div>
+                    )}
+                  </>
                 )}
               </div>
-              {!comb.cloning && (
-                <>
-                  {confirmDeleteId === comb.id ? (
-                    <div className="delete-confirm-inline" onClick={(e) => e.stopPropagation()}>
-                      <button
-                        className="btn-sm btn-danger"
-                        onClick={() => {
-                          setConfirmDeleteId(null);
-                          onDeleteComb(comb.id);
-                        }}
-                      >
-                        Sure?
-                      </button>
-                      <button className="btn-sm" onClick={() => setConfirmDeleteId(null)}>
-                        No
-                      </button>
-                    </div>
-                  ) : (
-                    <div className="sidebar-comb-actions">
-                      <button
-                        className="sidebar-comb-copy"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onCopyComb(comb.id);
-                        }}
-                        title="Copy comb"
-                      >
-                        &#x2398;
-                      </button>
-                      <button
-                        className="sidebar-comb-delete"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setConfirmDeleteId(comb.id);
-                        }}
-                        title="Delete comb"
-                      >
-                        x
-                      </button>
-                    </div>
-                  )}
-                </>
-              )}
-            </div>
-          ))}
+            );
+          })}
           {activeHive && combs.length === 0 && (
             <div className="sidebar-empty">No combs yet</div>
           )}

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -1,11 +1,16 @@
 import { useEffect, useRef, useState } from "react";
-import { Terminal } from "@xterm/xterm";
+import { Terminal, type ITerminalOptions, type ITerminalInitOnlyOptions } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import "@xterm/xterm/css/xterm.css";
+
+// vtExtensions is supported at runtime but not yet in xterm.js type definitions
+type TerminalOptions = ITerminalOptions & ITerminalInitOnlyOptions & {
+  vtExtensions?: { kittyKeyboard?: boolean };
+};
 
 interface DragDropPayload {
   paths: string[];
@@ -85,7 +90,7 @@ export function TerminalPane({ id, cwd, cmd, args, isVisible, shouldFocus, onFoc
         brightCyan: "#94e2d5",
         brightWhite: "#a6adc8",
       },
-    });
+    } as TerminalOptions);
 
     const fitAddon = new FitAddon();
     terminal.loadAddon(fitAddon);

--- a/src/hooks/useSortable.ts
+++ b/src/hooks/useSortable.ts
@@ -1,0 +1,184 @@
+import React, { useState, useRef, useEffect, useCallback } from "react";
+
+interface SortableItem {
+  id: string;
+}
+
+interface UseSortableOptions {
+  /** Pixels the pointer must move before drag activates (default: 5) */
+  threshold?: number;
+  /** CSS transition for items shifting into place (default: "transform 200ms cubic-bezier(0.2, 0, 0, 1)") */
+  transition?: string;
+}
+
+interface SortableItemProps {
+  ref: (el: HTMLDivElement | null) => void;
+  onPointerDown: (e: React.PointerEvent) => void;
+  style: React.CSSProperties | undefined;
+  /** True if this specific item is being dragged */
+  isDragged: boolean;
+}
+
+interface UseSortableReturn<T extends SortableItem> {
+  /** Whether a drag is actively in progress */
+  isDragging: boolean;
+  /** Index of the item being dragged, or null */
+  draggedIndex: number | null;
+  /** Get props to spread onto each sortable item element */
+  getItemProps: (index: number) => SortableItemProps;
+  /** The items in their current order (same ref as input when not dragging) */
+  items: T[];
+}
+
+const DEFAULT_THRESHOLD = 5;
+const DEFAULT_TRANSITION = "transform 200ms cubic-bezier(0.2, 0, 0, 1)";
+
+function reorder<T>(list: T[], from: number, to: number): T[] {
+  const result = [...list];
+  const [moved] = result.splice(from, 1);
+  result.splice(to, 0, moved);
+  return result;
+}
+
+export function useSortable<T extends SortableItem>(
+  items: T[],
+  onReorder: (ids: string[]) => void,
+  options?: UseSortableOptions,
+): UseSortableReturn<T> {
+  const threshold = options?.threshold ?? DEFAULT_THRESHOLD;
+  const transition = options?.transition ?? DEFAULT_TRANSITION;
+
+  const [dragState, setDragState] = useState<{
+    dragIndex: number;
+    overIndex: number;
+    activated: boolean;
+  } | null>(null);
+
+  // Refs for stable access in window event listeners
+  const dragRef = useRef(dragState);
+  dragRef.current = dragState;
+  const itemsRef = useRef(items);
+  itemsRef.current = items;
+
+  const pointerStartRef = useRef<{ x: number; y: number } | null>(null);
+  const itemElsById = useRef<Map<string, HTMLDivElement>>(new Map());
+  const itemRectsRef = useRef<{ id: string; mid: number }[]>([]);
+  const dragItemHeightRef = useRef(40);
+
+  function cacheItemRects() {
+    const rects: { id: string; mid: number }[] = [];
+    const ds = dragRef.current;
+    for (let i = 0; i < itemsRef.current.length; i++) {
+      const item = itemsRef.current[i];
+      const el = itemElsById.current.get(item.id);
+      if (el) {
+        const rect = el.getBoundingClientRect();
+        rects.push({ id: item.id, mid: rect.top + rect.height / 2 });
+        if (ds && i === ds.dragIndex) dragItemHeightRef.current = rect.height;
+      }
+    }
+    itemRectsRef.current = rects;
+  }
+
+  function findOverIndex(clientY: number): number {
+    const rects = itemRectsRef.current;
+    if (rects.length === 0) return 0;
+    if (clientY < rects[0].mid) return 0;
+    if (clientY >= rects[rects.length - 1].mid) return rects.length - 1;
+    for (let i = 0; i < rects.length; i++) {
+      if (clientY < rects[i].mid) return Math.max(0, i - 1);
+    }
+    return rects.length - 1;
+  }
+
+  function getTranslateY(i: number): number {
+    if (!dragState || !dragState.activated) return 0;
+    const { dragIndex, overIndex } = dragState;
+    if (dragIndex === overIndex) return 0;
+
+    const h = dragItemHeightRef.current;
+
+    if (i === dragIndex) return (overIndex - dragIndex) * h;
+    if (dragIndex < overIndex && i > dragIndex && i <= overIndex) return -h;
+    if (dragIndex > overIndex && i >= overIndex && i < dragIndex) return h;
+    return 0;
+  }
+
+  const handlePointerDown = useCallback((e: React.PointerEvent, index: number) => {
+    if (e.button !== 0) return;
+    if ((e.target as HTMLElement).closest("button")) return;
+    if (e.shiftKey) return;
+
+    e.preventDefault();
+    pointerStartRef.current = { x: e.clientX, y: e.clientY };
+    setDragState({ dragIndex: index, overIndex: index, activated: false });
+  }, []);
+
+  useEffect(() => {
+    function onPointerMove(e: PointerEvent) {
+      const ds = dragRef.current;
+      if (!ds) return;
+      const start = pointerStartRef.current;
+      if (!start) return;
+
+      if (!ds.activated) {
+        const dx = e.clientX - start.x;
+        const dy = e.clientY - start.y;
+        if (Math.abs(dx) < threshold && Math.abs(dy) < threshold) return;
+        cacheItemRects();
+        setDragState((prev) => prev ? { ...prev, activated: true } : null);
+        return;
+      }
+
+      const newOver = findOverIndex(e.clientY);
+      if (newOver !== ds.overIndex) {
+        setDragState((prev) => prev ? { ...prev, overIndex: newOver } : null);
+      }
+    }
+
+    function onPointerUp() {
+      const ds = dragRef.current;
+      if (!ds) return;
+      if (ds.activated && ds.dragIndex !== ds.overIndex) {
+        const reordered = reorder(itemsRef.current, ds.dragIndex, ds.overIndex);
+        onReorder(reordered.map((item) => item.id));
+      }
+      setDragState(null);
+      pointerStartRef.current = null;
+    }
+
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerUp);
+    return () => {
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerUp);
+    };
+  }, [onReorder, threshold]);
+
+  const isDragging = dragState?.activated ?? false;
+
+  const getItemProps = useCallback((index: number): SortableItemProps => {
+    const item = itemsRef.current[index];
+    const isDragged = isDragging && index === dragRef.current?.dragIndex;
+    const ty = getTranslateY(index);
+
+    return {
+      ref: (el: HTMLDivElement | null) => {
+        if (item) {
+          if (el) itemElsById.current.set(item.id, el);
+          else itemElsById.current.delete(item.id);
+        }
+      },
+      onPointerDown: (e: React.PointerEvent) => handlePointerDown(e, index),
+      style: isDragging ? {
+        transform: ty !== 0 ? `translateY(${ty}px)` : undefined,
+        transition,
+      } : undefined,
+      isDragged,
+    };
+  }, [isDragging, dragState?.dragIndex, dragState?.overIndex, handlePointerDown, transition]);
+
+  const draggedIndex = isDragging ? (dragState?.dragIndex ?? null) : null;
+
+  return { isDragging, draggedIndex, getItemProps, items };
+}


### PR DESCRIPTION
## Summary

- Add pointer-event-based drag-and-drop to reorder combs in the sidebar, with order persisted to `state.json` via a new `reorder_combs` Tauri command
- Extract reusable `useSortable` hook (`src/hooks/useSortable.ts`) with threshold activation, cached hit detection, and smooth CSS `translateY` animations
- Visual feedback: lifted item with shadow/scale, dimmed siblings, hover disabled during drag
- Shift+click bypasses drag to allow text selection
- Fix pre-existing TS error with a narrowed xterm.js `vtExtensions` type cast

## Demo


https://github.com/user-attachments/assets/246fed19-e174-45bd-a19b-a1b4646a1671



## Files changed

| File | What |
|------|------|
| `src/hooks/useSortable.ts` | New generic drag-and-drop reorder hook |
| `src/components/Sidebar.tsx` | Consume `useSortable` for comb list |
| `src/components/MainLayout.tsx` | `handleReorderCombs` with optimistic update |
| `src-tauri/src/hive.rs` | `reorder_combs` Tauri command |
| `src-tauri/src/lib.rs` | Register new command |
| `src/App.css` | Drag visual styles |
| `src/components/TerminalPane.tsx` | Narrow `vtExtensions` type cast (TS fix) |

## Known duplication

The `reorder_combs` logic in `hive.rs` mirrors `cli/src/config.rs::reorder_combs`. Both crates share no common library crate today — extracting a `beehive-common` crate would deduplicate this and other shared helpers (`load_hive_state`, types, etc.). Flagging as a follow-up.

## Test plan

- [ ] Drag combs in the sidebar — items shift smoothly, order commits on drop
- [ ] Close and reopen the app — order is preserved
- [ ] Shift+click on a comb — text is selectable, no drag starts
- [ ] Click without moving — comb opens normally (5px threshold)
- [ ] Hover highlight is suppressed during drag
- [ ] Delete/copy buttons still work during non-drag clicks

🤖 Generated with [Claude Code](https://claude.com/claude-code)