### PR TITLE
Fix terminal link opening in WebView

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beehive-tui"
-version = "0.1.99"
+version = "0.1.100"
 edition = "2021"
 
 [dependencies]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beehive",
-  "version": "0.1.99",
+  "version": "0.1.100",
   "description": "Orchestrate coding agents across isolated git workspaces",
   "license": "MIT",
   "author": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -236,7 +236,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "beehive"
-version = "0.1.99"
+version = "0.1.100"
 dependencies = [
  "dirs",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beehive"
-version = "0.1.99"
+version = "0.1.100"
 description = "Orchestrate coding agents across isolated git workspaces"
 authors = ["Mykyta Storozhenko <storozhenkomykyta@gmail.com>"]
 repository = "https://github.com/storozhenko98/beehive"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Beehive",
-  "version": "0.1.99",
+  "version": "0.1.100",
   "identifier": "com.beehive.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -5,6 +5,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import "@xterm/xterm/css/xterm.css";
 
 // vtExtensions is supported at runtime but not yet in xterm.js type definitions
@@ -94,7 +95,9 @@ export function TerminalPane({ id, cwd, cmd, args, isVisible, shouldFocus, onFoc
 
     const fitAddon = new FitAddon();
     terminal.loadAddon(fitAddon);
-    terminal.loadAddon(new WebLinksAddon());
+    terminal.loadAddon(new WebLinksAddon((_event, uri) => {
+      openUrl(uri).catch(() => {});
+    }));
     const unicode11 = new Unicode11Addon();
     terminal.loadAddon(unicode11);
     terminal.unicode.activeVersion = "11";


### PR DESCRIPTION
## Summary
- **Fix link clicking in terminal**: The `WebLinksAddon` default handler uses `window.open()`, which is silently blocked in Tauri's WebView sandbox. Links now route through the already-installed `@tauri-apps/plugin-opener` to open in the system browser.
- **Version bump** to `v0.1.100`

## Root Cause
When running apps like opencode inside Beehive's terminal, clickable links (URLs) wouldn't open. In a native terminal, `window.open()` works fine, but Tauri's WebView sandbox blocks it. The fix passes a custom handler to `WebLinksAddon` that calls `openUrl()` from `@tauri-apps/plugin-opener` — which was already installed and registered but unused for this purpose.

## Demo

https://github.com/user-attachments/assets/ba49c879-9807-4326-b8da-fb9354fb1f0d



## Test plan
- [x] Run `opencode` or any CLI that renders clickable URLs in a Beehive terminal pane
- [ ] Click a link — should open in system default browser
- [x] Verify normal terminal usage (typing, copy/paste) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)