### PR TITLE
Fix TUI branch picker to pre-select default branch

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1438,13 +1438,18 @@ fn handle_input_submit(
                 match list_branches(&app.beehive_dir, &hive_dir_name) {
                     Ok((branches, default_branch)) => {
                         app.status_message = None;
+                        // Pre-select the default branch in the picker
+                        let selected = branches
+                            .iter()
+                            .position(|b| b == &default_branch)
+                            .unwrap_or(0);
                         app.enter_sidebar_mode(AppMode::BranchPicker {
                             hive_dir_name,
                             comb_name: value,
                             branches,
                             default_branch,
                             filter: String::new(),
-                            selected: 0,
+                            selected,
                         });
                     }
                     Err(_) => {


### PR DESCRIPTION
## Summary
- When creating a new comb in the TUI, the branch picker now pre-selects the repository's default branch instead of always selecting the first branch in the list
- This aligns TUI behavior with the GUI, which already correctly pre-selects the default branch

## Changes
- `cli/src/main.rs`: Calculate the correct `selected` index based on the default branch position in the list

## Testing
1. Run `cargo run` in the `cli/` directory
2. Select a hive and press `n` to create a new comb
3. Enter a name and press Enter
4. Verify the branch picker highlights the branch marked with "(default)"