### PR TITLE
Make new comb creation graceful in TUI

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "beehive-tui"
-version = "0.1.98"
+version = "0.1.99"
 dependencies = [
  "crossterm",
  "dirs",

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -9,8 +9,10 @@ use crate::terminal::EmbeddedTerminal;
 pub struct CloneResult {
     pub comb: Result<Comb, String>,
     pub comb_name: String,
-    #[allow(dead_code)]
     pub hive_dir_name: String,
+    /// If true, this was a copy operation (auto-switch to new comb).
+    /// If false, this was a clone operation (graceful, don't switch focus).
+    pub is_copy: bool,
 }
 
 pub struct DeleteResult {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -388,15 +388,23 @@ fn check_pending_clone(app: &mut App) {
             app.activity = None;
             match result.comb {
                 Ok(comb) => {
-                    app.status_message = Some(format!("Created '{}'", result.comb_name));
-                    let id = comb.id.clone();
-                    let path = comb.path.clone();
-                    app.active_comb_id = Some(id.clone());
-                    app.refresh();
-                    app.open_terminal(&id, &path);
+                    if result.is_copy {
+                        // Copy: auto-switch to new comb (existing behavior)
+                        app.status_message = Some(format!("Copied '{}'", result.comb_name));
+                        let id = comb.id.clone();
+                        let path = comb.path.clone();
+                        app.active_comb_id = Some(id.clone());
+                        app.refresh();
+                        app.open_terminal(&id, &path);
+                    } else {
+                        // Clone: graceful — don't switch focus, user stays where they are
+                        app.status_message = Some(format!("Created '{}'", result.comb_name));
+                        app.refresh();
+                    }
                 }
                 Err(e) => {
-                    app.status_message = Some(format!("Clone failed: {}", e));
+                    let action = if result.is_copy { "Copy" } else { "Clone" };
+                    app.status_message = Some(format!("{} failed: {}", action, e));
                     app.refresh();
                 }
             }
@@ -965,6 +973,7 @@ fn start_async_clone(
             comb: result,
             comb_name: comb_name_clone,
             hive_dir_name: hive_dir_clone,
+            is_copy: false,
         });
     });
 
@@ -1033,6 +1042,7 @@ fn start_async_copy(
             comb: result,
             comb_name: comb_name_clone,
             hive_dir_name: hive_dir_clone,
+            is_copy: true,
         });
     });
 


### PR DESCRIPTION
## Summary
- When creating a new comb while working in another terminal, the user now stays focused on their current work
- The new comb appears in the sidebar with a status message ("Created 'comb-name'")
- User can switch to the new comb manually when ready
- Copy comb still auto-switches to the new comb (existing behavior preserved)

## Changes
- Added `is_copy` field to `CloneResult` to distinguish between clone and copy operations
- Updated `check_pending_clone()` to handle graceful behavior for new combs
- Clone operations no longer steal focus from the active terminal