### PR TITLE
Fix arrow keys in text inputs across GUI and TUI

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "beehive-tui"
-version = "0.1.99"
+version = "0.1.100"
 dependencies = [
  "crossterm",
  "dirs",

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -119,6 +119,7 @@ pub enum AppMode {
     Input {
         prompt: String,
         value: String,
+        cursor: usize,
         action: InputAction,
     },
     Confirm {
@@ -131,6 +132,7 @@ pub enum AppMode {
         branches: Vec<String>,
         default_branch: String,
         filter: String,
+        filter_cursor: usize,
         selected: usize,
     },
     /// Reordering a comb within its hive. Up/Down to move, m/Enter to confirm, Esc to cancel.
@@ -144,6 +146,7 @@ pub enum AppMode {
     CombFinder {
         targets: Vec<CombFinderTarget>,
         filter: String,
+        filter_cursor: usize,
         selected: usize,
     },
     DeleteCombSelection {
@@ -449,6 +452,7 @@ impl App {
         self.enter_sidebar_mode(AppMode::CombFinder {
             targets,
             filter: String::new(),
+            filter_cursor: 0,
             selected: 0,
         });
     }
@@ -871,6 +875,7 @@ impl App {
             self.enter_sidebar_mode(AppMode::Input {
                 prompt: "Comb name".to_string(),
                 value: String::new(),
+                cursor: 0,
                 action: InputAction::NewCombName {
                     hive_dir_name: dir_name,
                 },
@@ -901,6 +906,7 @@ impl App {
             self.enter_sidebar_mode(AppMode::Input {
                 prompt: format!("Copy '{}' as", comb.name),
                 value: String::new(),
+                cursor: 0,
                 action: InputAction::CopyCombName {
                     hive_dir_name: hive_dir_name.clone(),
                     source_comb_name: comb.name.clone(),
@@ -1023,6 +1029,7 @@ impl App {
         self.enter_sidebar_mode(AppMode::Input {
             prompt: "Repository (owner/repo or URL)".to_string(),
             value: String::new(),
+            cursor: 0,
             action: InputAction::AddHiveUrl,
         });
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -357,19 +357,43 @@ fn process_event(
                 handle_key(app, *key, terminal)?;
             }
             Event::Paste(text) => {
-                if let AppMode::Input { value, .. } = &mut app.mode {
-                    value.push_str(text);
+                if let AppMode::Input { value, cursor, .. } = &mut app.mode {
+                    let byte_pos = value
+                        .char_indices()
+                        .nth(*cursor)
+                        .map(|(i, _)| i)
+                        .unwrap_or(value.len());
+                    value.insert_str(byte_pos, text);
+                    *cursor += text.chars().count();
                 } else if let AppMode::BranchPicker {
-                    filter, selected, ..
+                    filter,
+                    filter_cursor,
+                    selected,
+                    ..
                 } = &mut app.mode
                 {
-                    filter.push_str(text);
+                    let byte_pos = filter
+                        .char_indices()
+                        .nth(*filter_cursor)
+                        .map(|(i, _)| i)
+                        .unwrap_or(filter.len());
+                    filter.insert_str(byte_pos, text);
+                    *filter_cursor += text.chars().count();
                     *selected = 0;
                 } else if let AppMode::CombFinder {
-                    filter, selected, ..
+                    filter,
+                    filter_cursor,
+                    selected,
+                    ..
                 } = &mut app.mode
                 {
-                    filter.push_str(text);
+                    let byte_pos = filter
+                        .char_indices()
+                        .nth(*filter_cursor)
+                        .map(|(i, _)| i)
+                        .unwrap_or(filter.len());
+                    filter.insert_str(byte_pos, text);
+                    *filter_cursor += text.chars().count();
                     *selected = 0;
                 }
             }
@@ -615,14 +639,64 @@ fn handle_input_key(
         KeyCode::Enter => {
             handle_input_submit(app, terminal)?;
         }
+        KeyCode::Left => {
+            if let AppMode::Input { cursor, .. } = &mut app.mode {
+                if *cursor > 0 {
+                    *cursor -= 1;
+                }
+            }
+        }
+        KeyCode::Right => {
+            if let AppMode::Input { value, cursor, .. } = &mut app.mode {
+                if *cursor < value.chars().count() {
+                    *cursor += 1;
+                }
+            }
+        }
+        KeyCode::Home => {
+            if let AppMode::Input { cursor, .. } = &mut app.mode {
+                *cursor = 0;
+            }
+        }
+        KeyCode::End => {
+            if let AppMode::Input { value, cursor, .. } = &mut app.mode {
+                *cursor = value.chars().count();
+            }
+        }
         KeyCode::Char(c) => {
-            if let AppMode::Input { value, .. } = &mut app.mode {
-                value.push(c);
+            if let AppMode::Input { value, cursor, .. } = &mut app.mode {
+                let byte_pos = value
+                    .char_indices()
+                    .nth(*cursor)
+                    .map(|(i, _)| i)
+                    .unwrap_or(value.len());
+                value.insert(byte_pos, c);
+                *cursor += 1;
             }
         }
         KeyCode::Backspace => {
-            if let AppMode::Input { value, .. } = &mut app.mode {
-                value.pop();
+            if let AppMode::Input { value, cursor, .. } = &mut app.mode {
+                if *cursor > 0 {
+                    *cursor -= 1;
+                    let byte_pos = value
+                        .char_indices()
+                        .nth(*cursor)
+                        .map(|(i, _)| i)
+                        .unwrap_or(value.len());
+                    value.remove(byte_pos);
+                }
+            }
+        }
+        KeyCode::Delete => {
+            if let AppMode::Input { value, cursor, .. } = &mut app.mode {
+                if *cursor < value.chars().count() {
+                    let byte_pos = value
+                        .char_indices()
+                        .nth(*cursor)
+                        .map(|(i, _)| i)
+                        .unwrap_or(value.len());
+                    value.remove(byte_pos);
+                }
             }
         }
         _ => {}
@@ -658,6 +732,7 @@ fn handle_comb_finder(
                 targets,
                 filter,
                 selected,
+                ..
             } = &mut app.mode
             {
                 let filtered_count = app::filter_comb_finder_targets(targets, filter).len();
@@ -673,6 +748,7 @@ fn handle_comb_finder(
                 targets,
                 filter,
                 selected,
+                ..
             } = &mut app.mode
             {
                 let filtered_count = app::filter_comb_finder_targets(targets, filter).len();
@@ -687,6 +763,7 @@ fn handle_comb_finder(
                 targets,
                 filter,
                 selected,
+                ..
             } = mode
             {
                 let filtered = app::filter_comb_finder_targets(&targets, &filter);
@@ -707,22 +784,61 @@ fn handle_comb_finder(
                 }
             }
         }
-        KeyCode::Char(c) => {
+        KeyCode::Left => {
+            if let AppMode::CombFinder { filter_cursor, .. } = &mut app.mode {
+                if *filter_cursor > 0 {
+                    *filter_cursor -= 1;
+                }
+            }
+        }
+        KeyCode::Right => {
             if let AppMode::CombFinder {
-                filter, selected, ..
+                filter,
+                filter_cursor,
+                ..
             } = &mut app.mode
             {
-                filter.push(c);
+                if *filter_cursor < filter.chars().count() {
+                    *filter_cursor += 1;
+                }
+            }
+        }
+        KeyCode::Char(c) => {
+            if let AppMode::CombFinder {
+                filter,
+                filter_cursor,
+                selected,
+                ..
+            } = &mut app.mode
+            {
+                let byte_pos = filter
+                    .char_indices()
+                    .nth(*filter_cursor)
+                    .map(|(i, _)| i)
+                    .unwrap_or(filter.len());
+                filter.insert(byte_pos, c);
+                *filter_cursor += 1;
                 *selected = 0;
             }
         }
         KeyCode::Backspace => {
             if let AppMode::CombFinder {
-                filter, selected, ..
+                filter,
+                filter_cursor,
+                selected,
+                ..
             } = &mut app.mode
             {
-                filter.pop();
-                *selected = 0;
+                if *filter_cursor > 0 {
+                    *filter_cursor -= 1;
+                    let byte_pos = filter
+                        .char_indices()
+                        .nth(*filter_cursor)
+                        .map(|(i, _)| i)
+                        .unwrap_or(filter.len());
+                    filter.remove(byte_pos);
+                    *selected = 0;
+                }
             }
         }
         _ => {}
@@ -814,6 +930,7 @@ fn handle_branch_picker(
                 default_branch,
                 filter,
                 selected,
+                ..
             } = mode
             {
                 let filtered = fuzzy::fuzzy_filter_strings(&branches, &filter);
@@ -833,22 +950,61 @@ fn handle_branch_picker(
                 start_async_clone(app, terminal, hive_dir_name, comb_name, branch)?;
             }
         }
-        KeyCode::Char(c) => {
+        KeyCode::Left => {
+            if let AppMode::BranchPicker { filter_cursor, .. } = &mut app.mode {
+                if *filter_cursor > 0 {
+                    *filter_cursor -= 1;
+                }
+            }
+        }
+        KeyCode::Right => {
             if let AppMode::BranchPicker {
-                filter, selected, ..
+                filter,
+                filter_cursor,
+                ..
             } = &mut app.mode
             {
-                filter.push(c);
+                if *filter_cursor < filter.chars().count() {
+                    *filter_cursor += 1;
+                }
+            }
+        }
+        KeyCode::Char(c) => {
+            if let AppMode::BranchPicker {
+                filter,
+                filter_cursor,
+                selected,
+                ..
+            } = &mut app.mode
+            {
+                let byte_pos = filter
+                    .char_indices()
+                    .nth(*filter_cursor)
+                    .map(|(i, _)| i)
+                    .unwrap_or(filter.len());
+                filter.insert(byte_pos, c);
+                *filter_cursor += 1;
                 *selected = 0;
             }
         }
         KeyCode::Backspace => {
             if let AppMode::BranchPicker {
-                filter, selected, ..
+                filter,
+                filter_cursor,
+                selected,
+                ..
             } = &mut app.mode
             {
-                filter.pop();
-                *selected = 0;
+                if *filter_cursor > 0 {
+                    *filter_cursor -= 1;
+                    let byte_pos = filter
+                        .char_indices()
+                        .nth(*filter_cursor)
+                        .map(|(i, _)| i)
+                        .unwrap_or(filter.len());
+                    filter.remove(byte_pos);
+                    *selected = 0;
+                }
             }
         }
         _ => {}
@@ -1369,6 +1525,7 @@ mod tests {
                 },
             ],
             filter: "bet".to_string(),
+            filter_cursor: 3,
             selected: 0,
         };
 
@@ -1387,6 +1544,7 @@ mod tests {
         app.mode = AppMode::Input {
             prompt: "Comb name".to_string(),
             value: String::new(),
+            cursor: 0,
             action: InputAction::AddHiveUrl,
         };
 
@@ -1409,6 +1567,7 @@ mod tests {
         app.mode = AppMode::Input {
             prompt: "Comb name".to_string(),
             value: "draft".to_string(),
+            cursor: 5,
             action: InputAction::AddHiveUrl,
         };
 
@@ -1459,6 +1618,7 @@ fn handle_input_submit(
                             branches,
                             default_branch,
                             filter: String::new(),
+                            filter_cursor: 0,
                             selected,
                         });
                     }
@@ -1473,6 +1633,7 @@ fn handle_input_submit(
                         app.enter_sidebar_mode(AppMode::Input {
                             prompt: format!("Branch [{}]", default_branch),
                             value: String::new(),
+                            cursor: 0,
                             action: InputAction::NewCombName { hive_dir_name },
                         });
                     }

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -59,7 +59,12 @@ pub fn render(frame: &mut Frame, app: &App) -> Rect {
 
     // Overlays
     match &app.mode {
-        AppMode::Input { prompt, value, .. } => render_input(frame, prompt, value),
+        AppMode::Input {
+            prompt,
+            value,
+            cursor,
+            ..
+        } => render_input(frame, prompt, value, *cursor),
         AppMode::Confirm { message, .. } => render_confirm(frame, message),
         AppMode::Help => render_help(frame),
         AppMode::Settings { preflight } => render_settings(frame, app, preflight),
@@ -67,6 +72,7 @@ pub fn render(frame: &mut Frame, app: &App) -> Rect {
             branches,
             default_branch,
             filter,
+            filter_cursor,
             selected,
             comb_name,
             ..
@@ -75,14 +81,16 @@ pub fn render(frame: &mut Frame, app: &App) -> Rect {
             branches,
             default_branch,
             filter,
+            *filter_cursor,
             *selected,
             comb_name,
         ),
         AppMode::CombFinder {
             targets,
             filter,
+            filter_cursor,
             selected,
-        } => render_comb_finder(frame, targets, filter, *selected),
+        } => render_comb_finder(frame, targets, filter, *filter_cursor, *selected),
         AppMode::Normal | AppMode::MovingComb { .. } | AppMode::DeleteCombSelection { .. } => {}
     }
 
@@ -732,11 +740,42 @@ fn render_help(frame: &mut Frame) {
     frame.render_widget(paragraph, inner);
 }
 
+/// Build spans for a filter input with cursor support.
+fn filter_cursor_spans(filter: &str, cursor: usize, cursor_color: Color) -> Vec<Span<'static>> {
+    let char_len = filter.chars().count();
+    let clamped = cursor.min(char_len);
+    let before: String = filter.chars().take(clamped).collect();
+    let after: String = filter.chars().skip(clamped).collect();
+
+    let mut spans = vec![
+        Span::styled(" / ".to_string(), Style::default().fg(OVERLAY0)),
+        Span::styled(before, Style::default().fg(TEXT)),
+    ];
+    if after.is_empty() {
+        spans.push(Span::styled(
+            "_".to_string(),
+            Style::default().fg(cursor_color),
+        ));
+    } else {
+        let cursor_ch: String = after.chars().take(1).collect();
+        let rest: String = after.chars().skip(1).collect();
+        spans.push(Span::styled(
+            cursor_ch,
+            Style::default().fg(MANTLE).bg(cursor_color),
+        ));
+        if !rest.is_empty() {
+            spans.push(Span::styled(rest, Style::default().fg(TEXT)));
+        }
+    }
+    spans
+}
+
 fn render_branch_picker(
     frame: &mut Frame,
     branches: &[String],
     default_branch: &str,
     filter: &str,
+    filter_cursor: usize,
     selected: usize,
     comb_name: &str,
 ) {
@@ -761,12 +800,8 @@ fn render_branch_picker(
 
     // Filter input line
     let filter_area = Rect::new(inner.x, inner.y, inner.width, 1);
-    let filter_line = Paragraph::new(Line::from(vec![
-        Span::styled(" / ", Style::default().fg(OVERLAY0)),
-        Span::styled(filter, Style::default().fg(TEXT)),
-        Span::styled("_", Style::default().fg(BLUE)),
-    ]))
-    .style(Style::default().bg(SURFACE0));
+    let filter_line = Paragraph::new(Line::from(filter_cursor_spans(filter, filter_cursor, BLUE)))
+        .style(Style::default().bg(SURFACE0));
     frame.render_widget(filter_line, filter_area);
 
     // Branch list
@@ -825,6 +860,7 @@ fn render_comb_finder(
     frame: &mut Frame,
     targets: &[crate::app::CombFinderTarget],
     filter: &str,
+    filter_cursor: usize,
     selected: usize,
 ) {
     let max_h = (frame.area().height - 4).min(18);
@@ -846,12 +882,8 @@ fn render_comb_finder(
     }
 
     let filter_area = Rect::new(inner.x, inner.y, inner.width, 1);
-    let filter_line = Paragraph::new(Line::from(vec![
-        Span::styled(" / ", Style::default().fg(OVERLAY0)),
-        Span::styled(filter, Style::default().fg(TEXT)),
-        Span::styled("_", Style::default().fg(BLUE)),
-    ]))
-    .style(Style::default().bg(SURFACE0));
+    let filter_line = Paragraph::new(Line::from(filter_cursor_spans(filter, filter_cursor, BLUE)))
+        .style(Style::default().bg(SURFACE0));
     frame.render_widget(filter_line, filter_area);
 
     let list_area = Rect::new(inner.x, inner.y + 1, inner.width, inner.height - 1);
@@ -1100,7 +1132,7 @@ fn convert_color(c: vt100::Color) -> Color {
     }
 }
 
-fn render_input(frame: &mut Frame, prompt: &str, value: &str) {
+fn render_input(frame: &mut Frame, prompt: &str, value: &str, cursor: usize) {
     let w = (frame.area().width / 2)
         .max(30)
         .min(frame.area().width.saturating_sub(2));
@@ -1114,12 +1146,30 @@ fn render_input(frame: &mut Frame, prompt: &str, value: &str) {
         .border_style(Style::default().fg(YELLOW))
         .style(Style::default().bg(MANTLE));
 
-    let paragraph = Paragraph::new(Line::from(vec![
-        Span::styled(format!(" {}", value), Style::default().fg(TEXT)),
-        Span::styled("_", Style::default().fg(YELLOW)),
-    ]))
-    .block(block);
+    let char_len = value.chars().count();
+    let clamped = cursor.min(char_len);
+    let before: String = value.chars().take(clamped).collect();
+    let after: String = value.chars().skip(clamped).collect();
 
+    let mut spans = vec![Span::styled(
+        format!(" {}", before),
+        Style::default().fg(TEXT),
+    )];
+    if after.is_empty() {
+        spans.push(Span::styled("_", Style::default().fg(YELLOW)));
+    } else {
+        let cursor_ch: String = after.chars().take(1).collect();
+        let rest: String = after.chars().skip(1).collect();
+        spans.push(Span::styled(
+            cursor_ch,
+            Style::default().fg(MANTLE).bg(YELLOW),
+        ));
+        if !rest.is_empty() {
+            spans.push(Span::styled(rest, Style::default().fg(TEXT)));
+        }
+    }
+
+    let paragraph = Paragraph::new(Line::from(spans)).block(block);
     frame.render_widget(paragraph, area);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beehive",
-  "version": "0.1.98",
+  "version": "0.1.100",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beehive",
-      "version": "0.1.98",
+      "version": "0.1.100",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",
@@ -61,7 +61,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1483,7 +1482,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1551,7 +1549,6 @@
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.1.0-beta.168.tgz",
       "integrity": "sha512-emtXKWZmyOZhcEg6StZ3qFU6M++FM506+2V/E//iqMitCDFfJAGJNJYUS5o0/PRN0MaIKo1ladXhfnozAKaGTA==",
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "addons/*"
       ]
@@ -1589,7 +1586,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1848,7 +1844,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1890,7 +1885,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2056,7 +2050,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -290,6 +290,8 @@ export function TerminalPane({ id, cwd, cmd, args, isVisible, shouldFocus, onFoc
   useEffect(() => {
     if (isVisible && shouldFocus && terminalRef.current) {
       requestAnimationFrame(() => {
+        // Don't steal focus from modal overlays (e.g. NewCombModal input fields)
+        if (document.querySelector('.modal-overlay')) return;
         terminalRef.current?.focus();
       });
     }


### PR DESCRIPTION
## Summary

- **Fixes arrow key cursor movement** in all text input fields (comb name, hive URL, branch filter, comb finder filter) — users can now move the cursor mid-string to edit typos instead of backspacing and retyping
- Applies to both the **GUI** (Tauri/React) and the **TUI** (ratatui/crossterm)

## Problem

**GUI:** When a terminal pane was open underneath a modal (e.g. New Comb), the terminal's focus-grabbing `useEffect` would steal focus from the modal's `<input>` on every React re-render (triggered by the 5-second branch polling). Once xterm.js had focus, it swallowed arrow key events.

**TUI:** Text inputs were completely append-only. The `handle_input_key` function only handled `Char`, `Backspace`, `Enter`, and `Esc` — arrow keys hit `_ => {}` and were silently ignored. There was no cursor position tracking at all.

## Changes

| File | What changed |
|---|---|
| `src/components/TerminalPane.tsx` | Added a guard to skip `terminal.focus()` when a `.modal-overlay` is present in the DOM |
| `cli/src/app.rs` | Added `cursor: usize` to `AppMode::Input`, `filter_cursor: usize` to `BranchPicker` and `CombFinder` |
| `cli/src/main.rs` | Implemented Left/Right/Home/End/Delete key handling with cursor-aware insert/backspace for all input modes; updated paste handler |
| `cli/src/ui.rs` | Updated `render_input`, `render_branch_picker`, and `render_comb_finder` to display cursor at the correct position |

## Testing

- `cargo check` passes cleanly
- All 65 existing tests pass (`cargo test`)
- Manual testing steps: open a text input, type a string, use arrow keys to navigate and edit mid-string