### PR TITLE
Add linux support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,3 +83,33 @@ jobs:
         run: |
           cp cli/target/aarch64-apple-darwin/release/beehive-tui beehive-tui-darwin-arm64
           gh release upload "${GITHUB_REF_NAME}" beehive-tui-darwin-arm64 --clobber || true
+
+  build-linux-tui:
+    needs: build-macos
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            cli
+
+      - name: Build Linux CLI
+        run: cd cli && cargo build --release --target x86_64-unknown-linux-gnu
+
+      - name: Upload Linux CLI binary
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cp cli/target/x86_64-unknown-linux-gnu/release/beehive-tui beehive-tui-linux-x64
+          gh release upload "${GITHUB_REF_NAME}" beehive-tui-linux-x64 --clobber || true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,35 @@ npx tsc --noEmit
 source "$HOME/.cargo/env" && cd src-tauri && cargo check
 ```
 
+## Experimental Linux TUI Validation
+
+The standalone TUI can be validated on Linux from macOS with Docker before testing on a real Linux host.
+
+```bash
+# Build the Linux test image and run a type-check
+./scripts/tui-linux-docker.sh check
+
+# Export a Linux executable for remote manual testing
+./scripts/tui-linux-docker.sh export
+```
+
+The exported binary is written to `dist/linux/beehive-tui-linux-x64`.
+
+For an interactive smoke test inside Docker:
+
+```bash
+./scripts/tui-linux-docker.sh run
+```
+
+For manual validation on a remote Linux machine:
+
+```bash
+scp dist/linux/beehive-tui-linux-x64 user@host:/tmp/beehive-tui
+ssh user@host 'chmod +x /tmp/beehive-tui && /tmp/beehive-tui'
+```
+
+The current target for manual validation is `x86_64` Linux with glibc.
+
 ## Project Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -14,13 +14,20 @@ Download the latest `.dmg` from [Releases](https://github.com/storozhenko98/beeh
 
 ### TUI
 
-One command, no dependencies beyond `git` and `gh`:
+macOS and Linux `x86_64` are supported for the TUI.
+
+Install directly:
 
 ```bash
 curl -fsSL beehiveapp.dev/install.sh | bash
 ```
 
 You'll be asked to choose `bh` or `beehive` as your command name. Auto-updates on startup.
+
+Or download the latest standalone TUI binary from [Releases](https://github.com/storozhenko98/beehive/releases/latest):
+
+- macOS: `beehive-tui-darwin-arm64`
+- Linux x64: `beehive-tui-linux-x64`
 
 ## Features
 
@@ -62,7 +69,7 @@ You'll be asked to choose `bh` or `beehive` as your command name. Auto-updates o
 gh auth login   # Required — Beehive uses gh for repo operations
 ```
 
-> **Note:** macOS only for now. Linux and Windows support is planned — contributions welcome.
+> **Note:** The desktop GUI is macOS-only for now. The standalone TUI supports macOS (Apple Silicon) and Linux x64. Windows support is not available yet.
 
 ## Building from Source
 
@@ -155,7 +162,7 @@ The GUI and TUI share the same config and data — you can use both interchangea
 |----------|-----|-----|
 | **macOS** (Apple Silicon) | Signed & notarized | Supported |
 | **macOS** (Intel) | Should work (untested) | Should work (untested) |
-| **Linux** | Not yet | Not yet |
+| **Linux** | Not yet | Supported (`x86_64` glibc) |
 | **Windows** | Not yet | Not yet |
 
 ## Contributing

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "beehive-tui"
-version = "0.1.101"
+version = "0.1.102"
 dependencies = [
  "crossterm",
  "dirs",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beehive-tui"
-version = "0.1.101"
+version = "0.1.102"
 edition = "2021"
 
 [dependencies]

--- a/cli/src/terminal.rs
+++ b/cli/src/terminal.rs
@@ -1,5 +1,7 @@
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use std::fs;
 use std::io::{Read, Write};
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 
@@ -19,6 +21,53 @@ fn detect_focus_reporting(data: &[u8], flag: &AtomicBool) {
             flag.store(false, Ordering::SeqCst);
         }
     }
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    let metadata = match fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(_) => return false,
+    };
+
+    if !metadata.is_file() {
+        return false;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        metadata.permissions().mode() & 0o111 != 0
+    }
+
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+fn resolve_login_shell_with_candidates(shell_env: Option<&str>, fallbacks: &[&str]) -> String {
+    if let Some(shell) = shell_env.map(str::trim).filter(|shell| !shell.is_empty()) {
+        if is_executable_file(Path::new(shell)) {
+            return shell.to_string();
+        }
+    }
+
+    for fallback in fallbacks {
+        if is_executable_file(Path::new(fallback)) {
+            return (*fallback).to_string();
+        }
+    }
+
+    shell_env
+        .map(str::trim)
+        .filter(|shell| !shell.is_empty())
+        .unwrap_or("/bin/sh")
+        .to_string()
+}
+
+fn resolve_login_shell() -> String {
+    let shell_env = std::env::var("SHELL").ok();
+    resolve_login_shell_with_candidates(shell_env.as_deref(), &["/bin/bash", "/bin/sh"])
 }
 
 pub struct EmbeddedTerminal {
@@ -51,7 +100,7 @@ impl EmbeddedTerminal {
             })
             .map_err(|e| format!("Failed to open PTY: {}", e))?;
 
-        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+        let shell = resolve_login_shell();
         let mut cmd = CommandBuilder::new(&shell);
         cmd.arg("-l");
         cmd.cwd(cwd);
@@ -849,6 +898,8 @@ fn set_clipboard(text: &[u8]) {
 mod tests {
     use super::*;
     use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
+    use std::fs;
+    use std::path::PathBuf;
 
     /// Helper: construct a key event with given code + modifiers
     fn key(code: KeyCode, mods: KeyModifiers) -> KeyEvent {
@@ -858,6 +909,61 @@ mod tests {
             kind: KeyEventKind::Press,
             state: KeyEventState::empty(),
         }
+    }
+
+    fn write_temp_shell(name: &str, executable: bool) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "beehive-terminal-test-{}-{}-{}",
+            std::process::id(),
+            name,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::write(&path, "#!/bin/sh\nexit 0\n").unwrap();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = if executable { 0o755 } else { 0o644 };
+            fs::set_permissions(&path, fs::Permissions::from_mode(mode)).unwrap();
+        }
+
+        path
+    }
+
+    #[test]
+    fn test_resolve_login_shell_prefers_valid_shell_env() {
+        let shell = write_temp_shell("preferred", true);
+        let resolved =
+            resolve_login_shell_with_candidates(Some(shell.to_str().unwrap()), &["/does/not/exist"]);
+        assert_eq!(resolved, shell.to_string_lossy());
+        fs::remove_file(shell).unwrap();
+    }
+
+    #[test]
+    fn test_resolve_login_shell_falls_back_when_shell_env_invalid() {
+        let fallback = write_temp_shell("fallback", true);
+        let resolved = resolve_login_shell_with_candidates(
+            Some("/does/not/exist"),
+            &[fallback.to_str().unwrap()],
+        );
+        assert_eq!(resolved, fallback.to_string_lossy());
+        fs::remove_file(fallback).unwrap();
+    }
+
+    #[test]
+    fn test_resolve_login_shell_skips_non_executable_shell_env() {
+        let shell = write_temp_shell("nonexec", false);
+        let fallback = write_temp_shell("fallback2", true);
+        let resolved = resolve_login_shell_with_candidates(
+            Some(shell.to_str().unwrap()),
+            &[fallback.to_str().unwrap()],
+        );
+        assert_eq!(resolved, fallback.to_string_lossy());
+        fs::remove_file(shell).unwrap();
+        fs::remove_file(fallback).unwrap();
     }
 
     // --- xterm_modifier tests ---

--- a/cli/src/update.rs
+++ b/cli/src/update.rs
@@ -6,6 +6,14 @@ const REPO: &str = "storozhenko98/beehive";
 const INSTALL_CMD: &str =
     "curl -fsSL https://raw.githubusercontent.com/storozhenko98/beehive/main/install.sh | bash";
 
+fn asset_name() -> Option<&'static str> {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("macos", "aarch64") => Some("beehive-tui-darwin-arm64"),
+        ("linux", "x86_64") => Some("beehive-tui-linux-x64"),
+        _ => None,
+    }
+}
+
 /// Check GitHub for a newer release. Returns `Some(version)` if an update is available.
 pub fn check_for_update() -> Option<String> {
     let output = run_cmd(
@@ -33,7 +41,12 @@ pub fn check_for_update() -> Option<String> {
 /// or Err with a user-friendly message (including the manual install command).
 pub fn self_update(version: &str) -> Result<(), String> {
     let tag = format!("v{}", version);
-    let asset = "beehive-tui-darwin-arm64";
+    let asset = asset_name().ok_or_else(|| {
+        format!(
+            "Auto-update is not available on this platform yet. Update manually:\n  {}",
+            INSTALL_CMD
+        )
+    })?;
     let url = format!(
         "https://github.com/{}/releases/download/{}/{}",
         REPO, tag, asset

--- a/docker/tui-linux/Dockerfile
+++ b/docker/tui-linux/Dockerfile
@@ -1,0 +1,18 @@
+FROM rust:1-bookworm
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        file \
+        git \
+        gh \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace/cli
+
+ENV PATH=/usr/local/cargo/bin:${PATH}
+ENV CARGO_TARGET_DIR=/workspace/cli/target
+
+CMD ["/bin/bash"]

--- a/install.sh
+++ b/install.sh
@@ -11,19 +11,31 @@ ARCH="$(uname -m)"
 
 case "$OS" in
   Darwin) OS_LABEL="darwin" ;;
+  Linux) OS_LABEL="linux" ;;
   *)
-    echo "Error: Unsupported OS: $OS (only macOS is supported currently)"
+    echo "Error: Unsupported OS: $OS (supported TUI targets: macOS arm64, Linux x64)"
     exit 1
     ;;
 esac
 
 case "$ARCH" in
   arm64|aarch64) ARCH_LABEL="arm64" ;;
+  x86_64) ARCH_LABEL="x64" ;;
   *)
-    echo "Error: Unsupported architecture: $ARCH (only Apple Silicon is supported currently)"
+    echo "Error: Unsupported architecture: $ARCH (supported TUI targets: arm64 on macOS, x64 on Linux)"
     exit 1
     ;;
 esac
+
+if [ "$OS_LABEL" = "linux" ] && [ "$ARCH_LABEL" != "x64" ]; then
+  echo "Error: Unsupported Linux architecture: $ARCH (supported TUI target: Linux x64)"
+  exit 1
+fi
+
+if [ "$OS_LABEL" = "darwin" ] && [ "$ARCH_LABEL" != "arm64" ]; then
+  echo "Error: Unsupported macOS architecture: $ARCH (supported TUI target: macOS arm64)"
+  exit 1
+fi
 
 ASSET_NAME="${BINARY_NAME}-${OS_LABEL}-${ARCH_LABEL}"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beehive",
-  "version": "0.1.101",
+  "version": "0.1.102",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beehive",
-      "version": "0.1.101",
+      "version": "0.1.102",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beehive",
-  "version": "0.1.101",
+  "version": "0.1.102",
   "description": "Orchestrate coding agents across isolated git workspaces",
   "license": "MIT",
   "author": {

--- a/scripts/tui-linux-docker.sh
+++ b/scripts/tui-linux-docker.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DOCKERFILE="${ROOT_DIR}/docker/tui-linux/Dockerfile"
+IMAGE_NAME="${BEEHIVE_TUI_LINUX_IMAGE:-beehive-tui-linux-test}"
+PLATFORM="${BEEHIVE_TUI_LINUX_PLATFORM:-linux/amd64}"
+ARTIFACT_DIR="${ROOT_DIR}/dist/linux"
+ARTIFACT_PATH="${ARTIFACT_DIR}/beehive-tui-linux-x64"
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/tui-linux-docker.sh <command>
+
+Commands:
+  build-image  Build the Linux test image.
+  check        Run cargo check for the TUI inside Docker.
+  build        Run a release build for the TUI inside Docker.
+  export       Build a release binary and copy it to dist/linux/beehive-tui-linux-x64.
+  run          Build and launch the TUI interactively inside Docker.
+  shell        Open an interactive shell inside the Linux test container.
+EOF
+}
+
+build_image() {
+  docker build \
+    --platform "${PLATFORM}" \
+    --tag "${IMAGE_NAME}" \
+    --file "${DOCKERFILE}" \
+    "${ROOT_DIR}/docker/tui-linux"
+}
+
+run_in_container() {
+  docker run --rm \
+    --platform "${PLATFORM}" \
+    -v "${ROOT_DIR}:/workspace" \
+    -w /workspace/cli \
+    "${IMAGE_NAME}" \
+    "$@"
+}
+
+run_interactive() {
+  docker run --rm -it \
+    --platform "${PLATFORM}" \
+    -v "${ROOT_DIR}:/workspace" \
+    -w /workspace/cli \
+    "${IMAGE_NAME}" \
+    "$@"
+}
+
+command_name="${1:-}"
+
+case "${command_name}" in
+  build-image)
+    build_image
+    ;;
+  check)
+    build_image
+    run_in_container cargo check
+    ;;
+  build)
+    build_image
+    run_in_container cargo build --release
+    ;;
+  export)
+    build_image
+    mkdir -p "${ARTIFACT_DIR}"
+    run_in_container /bin/bash -c \
+      "cargo build --release && install -m 755 target/release/beehive-tui /workspace/dist/linux/beehive-tui-linux-x64"
+    echo "Exported Linux binary to ${ARTIFACT_PATH}"
+    ;;
+  run)
+    build_image
+    run_interactive /bin/bash -c "cargo build --release && exec target/release/beehive-tui"
+    ;;
+  shell)
+    build_image
+    run_interactive /bin/bash
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -236,7 +236,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "beehive"
-version = "0.1.101"
+version = "0.1.102"
 dependencies = [
  "dirs",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beehive"
-version = "0.1.101"
+version = "0.1.102"
 description = "Orchestrate coding agents across isolated git workspaces"
 authors = ["Mykyta Storozhenko <storozhenkomykyta@gmail.com>"]
 repository = "https://github.com/storozhenko98/beehive"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Beehive",
-  "version": "0.1.101",
+  "version": "0.1.102",
   "identifier": "com.beehive.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/web/public/install.sh
+++ b/web/public/install.sh
@@ -11,19 +11,31 @@ ARCH="$(uname -m)"
 
 case "$OS" in
   Darwin) OS_LABEL="darwin" ;;
+  Linux) OS_LABEL="linux" ;;
   *)
-    echo "Error: Unsupported OS: $OS (only macOS is supported currently)"
+    echo "Error: Unsupported OS: $OS (supported TUI targets: macOS arm64, Linux x64)"
     exit 1
     ;;
 esac
 
 case "$ARCH" in
   arm64|aarch64) ARCH_LABEL="arm64" ;;
+  x86_64) ARCH_LABEL="x64" ;;
   *)
-    echo "Error: Unsupported architecture: $ARCH (only Apple Silicon is supported currently)"
+    echo "Error: Unsupported architecture: $ARCH (supported TUI targets: arm64 on macOS, x64 on Linux)"
     exit 1
     ;;
 esac
+
+if [ "$OS_LABEL" = "linux" ] && [ "$ARCH_LABEL" != "x64" ]; then
+  echo "Error: Unsupported Linux architecture: $ARCH (supported TUI target: Linux x64)"
+  exit 1
+fi
+
+if [ "$OS_LABEL" = "darwin" ] && [ "$ARCH_LABEL" != "arm64" ]; then
+  echo "Error: Unsupported macOS architecture: $ARCH (supported TUI target: macOS arm64)"
+  exit 1
+fi
 
 ASSET_NAME="${BINARY_NAME}-${OS_LABEL}-${ARCH_LABEL}"
 

--- a/web/src/components/cli-section.tsx
+++ b/web/src/components/cli-section.tsx
@@ -15,9 +15,10 @@ export function CliSection() {
         <h3 className="text-xl font-bold mb-2">Beehive TUI</h3>
         <p className="text-sm text-ctp-subtext0 leading-relaxed mb-5">
           A terminal-native interface with the same workspace management,
-          embedded terminals, and shared config as the desktop app. One install
-          command, no dependencies beyond git and gh. You&apos;ll be asked to
-          choose <code className="font-mono text-ctp-text">bh</code> or{" "}
+          embedded terminals, and shared config as the desktop app. Supported
+          on macOS and Linux x64. Install with one command, or grab the latest
+          binary from Releases. You&apos;ll be asked to choose{" "}
+          <code className="font-mono text-ctp-text">bh</code> or{" "}
           <code className="font-mono text-ctp-text">beehive</code> as your
           command name.
         </p>
@@ -27,6 +28,15 @@ export function CliSection() {
           </code>
         </div>
         <CopyButton text={INSTALL_CMD} />
+        <p className="mt-3 text-[13px] text-ctp-overlay0">
+          Linux x64 release binary:{" "}
+          <a
+            href="https://github.com/storozhenko98/beehive/releases/latest"
+            className="text-ctp-blue hover:text-ctp-sapphire underline underline-offset-4"
+          >
+            download from Releases
+          </a>
+        </p>
         <div className="flex gap-6 mt-6 flex-wrap">
           <div className="flex-1 min-w-[160px] text-[13px] text-ctp-subtext0">
             <strong className="text-ctp-text block mb-0.5 text-[13px]">

--- a/web/src/components/hero.tsx
+++ b/web/src/components/hero.tsx
@@ -40,6 +40,12 @@ export function Hero() {
           Download for macOS
         </a>
         <a
+          href="https://github.com/storozhenko98/beehive/releases/latest"
+          className="inline-flex items-center gap-2 px-7 py-3.5 rounded-xl text-[15px] font-semibold bg-ctp-surface0/70 text-ctp-text border border-ctp-surface0 hover:bg-ctp-surface0 hover:border-ctp-surface1 hover:-translate-y-px transition-all"
+        >
+          Download TUI for Linux
+        </a>
+        <a
           href="https://github.com/storozhenko98/beehive"
           className="inline-flex items-center gap-2 px-7 py-3.5 rounded-xl text-[15px] font-semibold bg-ctp-surface0/50 text-ctp-text border border-ctp-surface0 hover:bg-ctp-surface0 hover:border-ctp-surface1 hover:-translate-y-px transition-all"
         >
@@ -61,9 +67,9 @@ export function Hero() {
 
       {/* Meta info */}
       <p className="text-[13px] text-ctp-overlay0">
-        <span>Apple Silicon</span>
+        <span>GUI on macOS</span>
         <span className="before:content-['·'] before:mx-2 before:text-ctp-surface1">
-          Signed &amp; Notarized
+          TUI on macOS + Linux x64
         </span>
         <span className="before:content-['·'] before:mx-2 before:text-ctp-surface1">
           GUI + TUI share config


### PR DESCRIPTION
## Summary
This PR adds Linux support for the standalone TUI only. It does not add Linux support for the desktop GUI app.

The original blocker was a macOS-specific runtime assumption in the TUI: embedded terminals defaulted to `/bin/zsh`. That is not a safe default on Linux. This PR removes that assumption, validates the Linux path from macOS, and wires Linux TUI artifacts into release CD.

## What Changed
- make embedded terminal shell startup Linux-safe in the TUI
- prefer `$SHELL` when it points to an executable shell
- fall back to `/bin/bash`, then `/bin/sh` when `$SHELL` is missing or invalid
- add unit tests covering the shell-resolution behavior
- add a Docker-based Linux validation workflow for local testing from macOS
- add a Linux binary export path that writes `dist/linux/beehive-tui-linux-x64`
- add Linux x64 TUI release publishing in GitHub Actions/CD
- teach the install scripts to support Linux x64 TUI installs
- teach TUI self-update to select the Linux x64 asset on Linux
- update README and website copy to say Linux support is for the TUI only
- bump the app version to `0.1.102`

## Why These Changes Were Necessary
Before this PR, the TUI could compile under Linux, but that did not guarantee the embedded PTY experience would actually work on Linux machines. The shell bootstrap still assumed `/bin/zsh`, which is a real portability bug for Linux.

We also needed a practical path from development to distribution:
- validate Linux behavior locally from macOS
- verify the binary on a real Linux machine
- publish the Linux TUI binary in release CD
- make install and self-update aware of the Linux asset

Without those pieces, saying the TUI is supported on Linux would be incomplete.

## Why This Works
The TUI stack was already close to cross-platform:
- `portable-pty` for PTY management
- `crossterm` for terminal events
- `ratatui` for rendering
- `vt100` for terminal state parsing

That meant the main runtime blocker was shell selection, not a broader TUI architecture problem.

The distribution path now works because release CD uploads `beehive-tui-linux-x64`, the install scripts can resolve that asset on Linux x64, and the TUI updater selects the correct asset based on the running OS and architecture.

## Validation
- `cargo test`
- `bash -n install.sh`
- `bash -n web/public/install.sh`
- `bash -n scripts/tui-linux-docker.sh`
- `./scripts/tui-linux-docker.sh export`
- manual launch test on `dev-brian` (Ubuntu 24.04 x86_64)

## Scope And Tradeoffs
Included in this PR:
- Linux support for the standalone TUI on `x86_64` glibc systems
- Linux TUI release assets in CD
- Linux-aware TUI install and self-update behavior

Not included in this PR:
- Linux support for the desktop GUI app
- Linux GUI packaging or release artifacts
- ARM64 Linux or musl targets
- Windows support

One validation gap remains in this checkout: I could not run `web`'s `next build` locally here because the `web` app dependencies are not installed in this workspace, so the website copy changes were verified by inspection rather than by a successful local Next.js build.
