### PR TITLE
Reserve original comb directory name after inline rename

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "beehive-tui"
-version = "0.1.103"
+version = "0.1.105"
 dependencies = [
  "crossterm",
  "dirs",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beehive-tui"
-version = "0.1.103"
+version = "0.1.105"
 edition = "2021"
 
 [dependencies]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -349,41 +349,12 @@ pub fn rename_comb(
         .collect();
     validate_comb_name(new_name, &existing_combs)?;
 
-    let old_path = PathBuf::from(&state.combs[index].path);
-    let Some(parent) = old_path.parent() else {
-        return Err(format!("Invalid comb path '{}'", state.combs[index].path));
-    };
-    let new_path = parent.join(new_name);
-
-    if rename_target_conflicts(&old_path, &new_path)? {
-        return Err(format!("Directory '{}' already exists", new_name));
-    }
-
-    fs::rename(&old_path, &new_path).map_err(|e| format!("Failed to rename comb directory: {}", e))?;
-
     state.combs[index].name = new_name.to_string();
-    state.combs[index].path = new_path.to_string_lossy().to_string();
     let renamed = state.combs[index].clone();
 
-    if let Err(e) = save_hive_state(beehive_dir, hive_dir_name, &state) {
-        let _ = fs::rename(&new_path, &old_path);
-        return Err(format!("Failed to save renamed comb: {}", e));
-    }
+    save_hive_state(beehive_dir, hive_dir_name, &state)?;
 
     Ok(renamed)
-}
-
-fn rename_target_conflicts(old_path: &Path, new_path: &Path) -> Result<bool, String> {
-    if !new_path.exists() {
-        return Ok(false);
-    }
-
-    Ok(
-        fs::canonicalize(old_path)
-            .map_err(|e| format!("Failed to inspect current comb directory: {}", e))?
-            != fs::canonicalize(new_path)
-                .map_err(|e| format!("Failed to inspect rename target: {}", e))?,
-    )
 }
 
 pub fn validate_comb_name(name: &str, existing_combs: &[Comb]) -> Result<(), String> {
@@ -405,10 +376,17 @@ pub fn validate_comb_name(name: &str, existing_combs: &[Comb]) -> Result<(), Str
     if name == ".hive" {
         return Err("Reserved name".to_string());
     }
-    if existing_combs.iter().any(|c| c.name == name) {
+    if existing_combs
+        .iter()
+        .any(|c| c.name == name || comb_path_basename(c) == Some(name))
+    {
         return Err(format!("'{}' already exists", name));
     }
     Ok(())
+}
+
+fn comb_path_basename(comb: &Comb) -> Option<&str> {
+    Path::new(&comb.path).file_name().and_then(|name| name.to_str())
 }
 
 pub fn parse_repo_url(url: &str) -> Result<(String, String), String> {
@@ -502,15 +480,13 @@ pub fn chrono_now() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(unix)]
-    use std::os::unix::fs::symlink;
 
     fn unique_temp_dir() -> PathBuf {
         std::env::temp_dir().join(format!("beehive-config-test-{}", uuid::Uuid::new_v4()))
     }
 
     #[test]
-    fn rename_comb_updates_state_and_directory() {
+    fn rename_comb_updates_state_without_moving_directory() {
         let beehive_dir = unique_temp_dir();
         let hive_dir_name = "repo_demo";
         let hive_dir = beehive_dir.join(hive_dir_name);
@@ -545,45 +521,54 @@ mod tests {
         let renamed =
             rename_comb(beehive_dir.to_str().unwrap(), hive_dir_name, "comb-1", "beta").unwrap();
 
-        let new_dir = hive_dir.join("beta");
         assert_eq!(renamed.name, "beta");
-        assert_eq!(renamed.path, new_dir.to_string_lossy().to_string());
-        assert!(!old_dir.exists());
-        assert!(new_dir.exists());
+        assert_eq!(renamed.path, old_dir.to_string_lossy().to_string());
+        assert!(old_dir.exists());
 
         let saved = load_hive_state(beehive_dir.to_str().unwrap(), hive_dir_name).unwrap();
         assert_eq!(saved.combs[0].name, "beta");
-        assert_eq!(saved.combs[0].path, new_dir.to_string_lossy().to_string());
+        assert_eq!(saved.combs[0].path, old_dir.to_string_lossy().to_string());
 
         let _ = fs::remove_dir_all(&beehive_dir);
     }
 
-    #[cfg(unix)]
     #[test]
-    fn rename_target_conflicts_allows_same_entry() {
-        let temp_dir = unique_temp_dir();
-        let old_dir = temp_dir.join("alpha");
-        let alias_dir = temp_dir.join("alpha-link");
+    fn renamed_comb_reserves_original_directory_name() {
+        let beehive_dir = unique_temp_dir();
+        let hive_dir_name = "repo_demo";
+        let hive_dir = beehive_dir.join(hive_dir_name);
+        let old_dir = hive_dir.join("alpha");
+        fs::create_dir_all(old_dir.join(".git")).unwrap();
+        fs::create_dir_all(hive_dir.join(".hive")).unwrap();
 
-        fs::create_dir_all(&old_dir).unwrap();
-        symlink(&old_dir, &alias_dir).unwrap();
+        let state = HiveState {
+            info: HiveInfo {
+                dir_name: hive_dir_name.to_string(),
+                repo_url: "https://example.com/repo.git".to_string(),
+                repo_name: "repo".to_string(),
+                owner: "owner".to_string(),
+                description: None,
+                default_branch: Some("main".to_string()),
+                custom_buttons: vec![],
+            },
+            combs: vec![Comb {
+                id: "comb-1".to_string(),
+                name: "alpha".to_string(),
+                branch: "main".to_string(),
+                path: old_dir.to_string_lossy().to_string(),
+                created_at: "0".to_string(),
+                panes: vec![],
+                cloning: false,
+            }],
+        };
+        save_hive_state(beehive_dir.to_str().unwrap(), hive_dir_name, &state).unwrap();
 
-        assert!(!rename_target_conflicts(&old_dir, &alias_dir).unwrap());
+        rename_comb(beehive_dir.to_str().unwrap(), hive_dir_name, "comb-1", "beta").unwrap();
 
-        let _ = fs::remove_dir_all(&temp_dir);
-    }
+        let saved = load_hive_state(beehive_dir.to_str().unwrap(), hive_dir_name).unwrap();
+        let error = validate_comb_name("alpha", &saved.combs).unwrap_err();
+        assert_eq!(error, "'alpha' already exists");
 
-    #[test]
-    fn rename_target_conflicts_rejects_other_entry() {
-        let temp_dir = unique_temp_dir();
-        let old_dir = temp_dir.join("alpha");
-        let other_dir = temp_dir.join("beta");
-
-        fs::create_dir_all(&old_dir).unwrap();
-        fs::create_dir_all(&other_dir).unwrap();
-
-        assert!(rename_target_conflicts(&old_dir, &other_dir).unwrap());
-
-        let _ = fs::remove_dir_all(&temp_dir);
+        let _ = fs::remove_dir_all(&beehive_dir);
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beehive",
-  "version": "0.1.103",
+  "version": "0.1.105",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beehive",
-      "version": "0.1.103",
+      "version": "0.1.105",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beehive",
-  "version": "0.1.103",
+  "version": "0.1.105",
   "description": "Orchestrate coding agents across isolated git workspaces",
   "license": "MIT",
   "author": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -236,7 +236,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "beehive"
-version = "0.1.103"
+version = "0.1.105"
 dependencies = [
  "dirs",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beehive"
-version = "0.1.103"
+version = "0.1.105"
 description = "Orchestrate coding agents across isolated git workspaces"
 authors = ["Mykyta Storozhenko <storozhenkomykyta@gmail.com>"]
 repository = "https://github.com/storozhenko98/beehive"

--- a/src-tauri/src/hive.rs
+++ b/src-tauri/src/hive.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 use tauri::{AppHandle, Emitter};
 
@@ -895,7 +895,7 @@ pub async fn rename_comb(
         return Err(format!("Comb '{}' not found", comb_id));
     };
 
-    if state.combs[index].cloning {
+    if state.combs[index].cloning || state.combs[index].operation.is_some() {
         return Err("Cannot rename a comb that is still in progress".to_string());
     }
 
@@ -913,42 +913,12 @@ pub async fn rename_comb(
         .collect();
     validate_comb_name(&new_name, &existing_combs)?;
 
-    let old_path = PathBuf::from(&state.combs[index].path);
-    let Some(parent) = old_path.parent() else {
-        return Err(format!("Invalid comb path '{}'", state.combs[index].path));
-    };
-    let new_path = parent.join(&new_name);
-
-    if rename_target_conflicts(&old_path, &new_path)? {
-        return Err(format!("Directory '{}' already exists", new_name));
-    }
-
-    fs::rename(&old_path, &new_path)
-        .map_err(|e| format!("Failed to rename comb directory: {}", e))?;
-
     state.combs[index].name = new_name;
-    state.combs[index].path = new_path.to_string_lossy().to_string();
     let renamed = state.combs[index].clone();
 
-    if let Err(e) = save_hive_state(&beehive_dir, &dir_name, &state) {
-        let _ = fs::rename(&new_path, &old_path);
-        return Err(format!("Failed to save renamed comb: {}", e));
-    }
+    save_hive_state(&beehive_dir, &dir_name, &state)?;
 
     Ok(renamed)
-}
-
-fn rename_target_conflicts(old_path: &Path, new_path: &Path) -> Result<bool, String> {
-    if !new_path.exists() {
-        return Ok(false);
-    }
-
-    Ok(
-        fs::canonicalize(old_path)
-            .map_err(|e| format!("Failed to inspect current comb directory: {}", e))?
-            != fs::canonicalize(new_path)
-                .map_err(|e| format!("Failed to inspect rename target: {}", e))?,
-    )
 }
 
 #[tauri::command]
@@ -1010,10 +980,17 @@ fn validate_comb_name(name: &str, existing_combs: &[Comb]) -> Result<(), String>
     if name == ".hive" {
         return Err("'.hive' is a reserved name".to_string());
     }
-    if existing_combs.iter().any(|c| c.name == name) {
+    if existing_combs
+        .iter()
+        .any(|c| c.name == name || comb_path_basename(c) == Some(name))
+    {
         return Err(format!("A comb named '{}' already exists", name));
     }
     Ok(())
+}
+
+fn comb_path_basename(comb: &Comb) -> Option<&str> {
+    Path::new(&comb.path).file_name().and_then(|name| name.to_str())
 }
 
 fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), String> {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Beehive",
-  "version": "0.1.103",
+  "version": "0.1.105",
   "identifier": "com.beehive.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -24,7 +24,10 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["app", "dmg"],
+    "targets": [
+      "app",
+      "dmg"
+    ],
     "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
## Summary
- keep inline rename behavior without moving the worktree directory
- reserve the original directory basename so later create/copy operations cannot alias and delete the renamed comb path
- bump release version to 0.1.105

## What this solves
This PR fixes a regression introduced by inline comb rename. After a rename, the comb display name changed but its on-disk directory path intentionally stayed at the old basename.

The bug was that the old basename then appeared available for reuse even though it still referred to the renamed comb's actual worktree directory. A later create or copy using that old name could target the same path and, on failure cleanup, remove the renamed comb's directory.

This change preserves the current inline-rename behavior without moving the worktree, but treats the original directory basename as still reserved so later operations cannot alias or delete that existing comb path.

## Verification
- cargo test --manifest-path cli/Cargo.toml
- cargo check --manifest-path src-tauri/Cargo.toml