### PR TITLE
Fix CLI terminal query handling for scrolling support

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -22,7 +22,7 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "beehive-tui"
-version = "0.1.103"
+version = "0.1.104"
 dependencies = [
  "crossterm",
  "dirs",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beehive-tui"
-version = "0.1.103"
+version = "0.1.104"
 edition = "2021"
 
 [dependencies]

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -826,7 +826,7 @@ impl App {
         let term_cols = (cols * 70 / 100).max(20);
         let term_rows = rows.saturating_sub(3).max(5);
 
-        match EmbeddedTerminal::new(comb_path, term_rows, term_cols) {
+        match EmbeddedTerminal::new(comb_path, term_rows, term_cols, self.keyboard_enhanced) {
             Ok(term) => {
                 self.terminals.insert(comb_id.to_string(), term);
                 self.focus = Focus::Terminal;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -323,7 +323,7 @@ fn process_event(
                 // Ctrl+Space: toggle focus back to sidebar
                 if is_focus_toggle(key) {
                     app.focus = Focus::Sidebar;
-                } else if let Some(t) = app.active_terminal() {
+                } else if let Some(t) = app.active_terminal_mut() {
                     // All key events go through the unified encoding pipeline.
                     // No special-casing for Ctrl+C etc. — key_to_bytes handles it.
                     let bytes = terminal::event_to_bytes(evt, t, term_area);
@@ -342,7 +342,25 @@ fn process_event(
                 }
             }
             Event::Mouse(mouse) => {
-                if let Some(t) = app.active_terminal() {
+                let focus_label = match app.focus {
+                    Focus::Sidebar => "sidebar",
+                    Focus::Terminal => "terminal",
+                };
+                if let Some(t) = app.active_terminal_mut() {
+                    if key_trace {
+                        eprintln!(
+                            "[mouse-trace] kind={:?} col={} row={} mods={:?} focus={} mouse_mode={:?} alt_screen={} inner_enhanced={}",
+                            mouse.kind,
+                            mouse.column,
+                            mouse.row,
+                            mouse.modifiers,
+                            focus_label,
+                            t.mouse_protocol_mode(),
+                            t.alternate_screen(),
+                            t.keyboard_enhanced(),
+                        );
+                    }
+
                     let should_open_url =
                         matches!(mouse.kind, event::MouseEventKind::Up(event::MouseButton::Left))
                             && t.mouse_protocol_mode() == vt100::MouseProtocolMode::None;
@@ -368,12 +386,17 @@ fn process_event(
 
                     let input = terminal::event_to_bytes(evt, t, term_area);
                     if !input.is_empty() {
+                        if key_trace {
+                            eprintln!("[mouse-trace] → PTY {} bytes: {:02x?}", input.len(), input);
+                        }
                         t.write_input(&input);
+                    } else if key_trace {
+                        eprintln!("[mouse-trace] → PTY <none>");
                     }
                 }
             }
             Event::Paste(_) | Event::FocusGained | Event::FocusLost => {
-                if let Some(t) = app.active_terminal() {
+                if let Some(t) = app.active_terminal_mut() {
                     let bytes = terminal::event_to_bytes(evt, t, term_area);
                     if !bytes.is_empty() {
                         t.write_input(&bytes);

--- a/cli/src/terminal.rs
+++ b/cli/src/terminal.rs
@@ -8,17 +8,71 @@ use std::sync::{mpsc, Arc, Mutex};
 use crate::config::full_path;
 use crate::keyboard::{self, KeyboardProtocol};
 
-/// Detect DECSET 1004 (focus reporting) requests in the PTY output stream.
-/// Scans for \x1b[?1004h (enable) and \x1b[?1004l (disable).
-fn detect_focus_reporting(data: &[u8], flag: &AtomicBool) {
-    let enable = b"\x1b[?1004h";
-    let disable = b"\x1b[?1004l";
-    if data.len() >= enable.len() {
-        if data.windows(enable.len()).any(|w| w == enable) {
-            flag.store(true, Ordering::SeqCst);
+/// Tracks DECSET 1004 focus-reporting changes seen in the PTY output stream.
+///
+/// We keep a short tail buffer so mode sequences split across PTY reads are still
+/// detected, and we parse parameter lists so combined DECSET/DECRST sequences
+/// like `CSI ? 1000 ; 1004 h` are handled correctly.
+struct FocusReportingDetector {
+    tail: Vec<u8>,
+}
+
+impl FocusReportingDetector {
+    fn new() -> Self {
+        Self { tail: Vec::new() }
+    }
+
+    fn process(&mut self, data: &[u8], focus_reporting: &AtomicBool) {
+        let mut buf = Vec::with_capacity(self.tail.len() + data.len());
+        buf.extend_from_slice(&self.tail);
+        buf.extend_from_slice(data);
+        apply_focus_reporting_mode(&buf, focus_reporting);
+
+        const MAX_TAIL: usize = 64;
+        let keep = buf.len().min(MAX_TAIL);
+        self.tail.clear();
+        self.tail.extend_from_slice(&buf[buf.len() - keep..]);
+    }
+}
+
+fn apply_focus_reporting_mode(data: &[u8], focus_reporting: &AtomicBool) {
+    let len = data.len();
+    let mut i = 0;
+
+    while i + 3 < len {
+        if data[i] != 0x1b || data[i + 1] != b'[' || data[i + 2] != b'?' {
+            i += 1;
+            continue;
         }
-        if data.windows(disable.len()).any(|w| w == disable) {
-            flag.store(false, Ordering::SeqCst);
+        i += 3;
+
+        let params_start = i;
+        while i < len {
+            let b = data[i];
+            if b.is_ascii_digit() || b == b';' {
+                i += 1;
+                continue;
+            }
+            if b == b'h' || b == b'l' {
+                let enabled = b == b'h';
+                for param in data[params_start..i].split(|&ch| ch == b';') {
+                    if let Some(mode) = std::str::from_utf8(param)
+                        .ok()
+                        .and_then(|s| s.parse::<u16>().ok())
+                    {
+                        if mode == 1004 {
+                            focus_reporting.store(enabled, Ordering::SeqCst);
+                        }
+                    }
+                }
+                i += 1;
+                break;
+            }
+
+            // Not a DEC private mode we understand; continue scanning from the
+            // next byte so we can recover from unrelated CSI sequences.
+            i = params_start;
+            break;
         }
     }
 }
@@ -85,10 +139,19 @@ pub struct EmbeddedTerminal {
     focus_reporting: Arc<AtomicBool>,
     /// Keyboard protocol state negotiated by the inner app (legacy vs enhanced).
     keyboard_protocol: KeyboardProtocol,
+    /// Whether the outer terminal supports kitty keyboard enhancement.
+    outer_keyboard_enhanced: bool,
+    /// Tail buffer for terminal query sequences that may be split across PTY reads.
+    query_tail: Vec<u8>,
 }
 
 impl EmbeddedTerminal {
-    pub fn new(cwd: &str, rows: u16, cols: u16) -> Result<Self, String> {
+    pub fn new(
+        cwd: &str,
+        rows: u16,
+        cols: u16,
+        outer_keyboard_enhanced: bool,
+    ) -> Result<Self, String> {
         let pty_system = native_pty_system();
 
         let pair = pty_system
@@ -139,13 +202,14 @@ impl EmbeddedTerminal {
         std::thread::spawn(move || {
             let mut buf = [0u8; 16384];
             let mut osc52 = Osc52Detector::new();
+            let mut focus_detector = FocusReportingDetector::new();
             loop {
                 match reader.read(&mut buf) {
                     Ok(0) => break,
                     Ok(n) => {
                         let data = &buf[..n];
                         osc52.process(data);
-                        detect_focus_reporting(data, &focus_clone);
+                        focus_detector.process(data, &focus_clone);
                         keyboard::detect_keyboard_protocol(data, &kb_flags_clone);
                         if output_tx.send(data.to_vec()).is_err() {
                             break; // receiver dropped
@@ -166,6 +230,8 @@ impl EmbeddedTerminal {
             alive,
             focus_reporting,
             keyboard_protocol,
+            outer_keyboard_enhanced,
+            query_tail: Vec::new(),
         })
     }
 
@@ -175,7 +241,7 @@ impl EmbeddedTerminal {
     pub fn process_pending_output(&mut self) -> bool {
         let mut got_data = false;
         while let Ok(data) = self.output_rx.try_recv() {
-            self.parser.process(&data);
+            self.process_output_chunk(&data);
             got_data = true;
         }
         got_data
@@ -223,6 +289,10 @@ impl EmbeddedTerminal {
         self.parser.screen().application_cursor()
     }
 
+    pub fn alternate_screen(&self) -> bool {
+        self.parser.screen().alternate_screen()
+    }
+
     pub fn mouse_protocol_mode(&self) -> vt100::MouseProtocolMode {
         self.parser.screen().mouse_protocol_mode()
     }
@@ -240,6 +310,207 @@ impl EmbeddedTerminal {
     pub fn keyboard_enhanced(&self) -> bool {
         self.keyboard_protocol.is_enhanced()
     }
+
+    fn process_output_chunk(&mut self, data: &[u8]) {
+        let mut buf = Vec::with_capacity(self.query_tail.len() + data.len());
+        buf.extend_from_slice(&self.query_tail);
+        buf.extend_from_slice(data);
+
+        let mut responses = Vec::new();
+        let mut i = 0;
+        let mut parsed_until = 0;
+        let mut tail_start = buf.len();
+
+        while i < buf.len() {
+            if buf[i] != 0x1b {
+                i += 1;
+                continue;
+            }
+
+            if i > parsed_until {
+                self.parser.process(&buf[parsed_until..i]);
+                parsed_until = i;
+            }
+
+            let Some((consumed, response)) = self.match_terminal_query(&buf[i..]) else {
+                tail_start = i;
+                break;
+            };
+
+            if let Some(response) = response {
+                responses.extend_from_slice(&response);
+            }
+            let end = i + consumed;
+            self.parser.process(&buf[i..end]);
+            parsed_until = end;
+            i = end;
+        }
+
+        let parse_end = tail_start.min(buf.len());
+        if parsed_until < parse_end {
+            self.parser.process(&buf[parsed_until..parse_end]);
+        }
+
+        self.query_tail.clear();
+        if tail_start < buf.len() {
+            let keep = (buf.len() - tail_start).min(64);
+            self.query_tail
+                .extend_from_slice(&buf[buf.len() - keep..]);
+        }
+
+        if !responses.is_empty() {
+            self.write_input(&responses);
+        }
+    }
+
+    fn match_terminal_query(&self, data: &[u8]) -> Option<(usize, Option<Vec<u8>>)> {
+        if data.len() < 2 {
+            return None;
+        }
+
+        if data[1] == b'[' {
+            return self.match_csi_query(data);
+        }
+
+        None
+    }
+
+    fn match_csi_query(&self, data: &[u8]) -> Option<(usize, Option<Vec<u8>>)> {
+        if data.len() < 3 {
+            return None;
+        }
+
+        match data[2] {
+            b'?' => self.match_private_csi_query(data),
+            b'c' => Some((3, Some(primary_device_attributes_response()))),
+            b'0' if data.get(3) == Some(&b'c') => Some((4, Some(primary_device_attributes_response()))),
+            b'>' => self.match_secondary_csi_query(data),
+            _ => Some((1, None)),
+        }
+    }
+
+    fn match_private_csi_query(&self, data: &[u8]) -> Option<(usize, Option<Vec<u8>>)> {
+        if data.len() < 4 {
+            return None;
+        }
+
+        if data[3] == b'u' {
+            return Some((
+                4,
+                Some(keyboard::query_response(self.outer_keyboard_enhanced)),
+            ));
+        }
+
+        let mut i = 3;
+        while i < data.len() && data[i].is_ascii_digit() {
+            i += 1;
+        }
+
+        if i == data.len() {
+            return None;
+        }
+
+        let param = std::str::from_utf8(&data[3..i])
+            .ok()
+            .and_then(|s| s.parse::<u16>().ok());
+
+        match data[i] {
+            b'n' if param == Some(6) => {
+                let (row, col) = self.parser.screen().cursor_position();
+                Some((i + 1, Some(format!("\x1b[?{};{}R", row + 1, col + 1).into_bytes())))
+            }
+            b'$' => {
+                if data.get(i + 1) == Some(&b'p') {
+                    Some((
+                        i + 2,
+                        Some(dec_mode_response(
+                            param.unwrap_or_default(),
+                            self.focus_reporting(),
+                            self.alternate_screen(),
+                            self.mouse_protocol_mode(),
+                            self.mouse_protocol_encoding(),
+                            self.bracketed_paste(),
+                        )),
+                    ))
+                } else if i + 1 >= data.len() {
+                    None
+                } else {
+                    Some((1, None))
+                }
+            }
+            _ => Some((1, None)),
+        }
+    }
+
+    fn match_secondary_csi_query(&self, data: &[u8]) -> Option<(usize, Option<Vec<u8>>)> {
+        if data.len() < 4 {
+            return None;
+        }
+
+        let mut i = 3;
+        while i < data.len() && data[i].is_ascii_digit() {
+            i += 1;
+        }
+
+        if i == data.len() {
+            return None;
+        }
+
+        match data[i] {
+            b'c' => Some((i + 1, Some(secondary_device_attributes_response()))),
+            b'q' => Some((i + 1, Some(xtversion_response()))),
+            _ => Some((1, None)),
+        }
+    }
+}
+
+fn primary_device_attributes_response() -> Vec<u8> {
+    b"\x1b[?62;1;4;6;22c".to_vec()
+}
+
+fn secondary_device_attributes_response() -> Vec<u8> {
+    b"\x1b[>0;10;1c".to_vec()
+}
+
+fn xtversion_response() -> Vec<u8> {
+    b"\x1bP>|Beehive\x1b\\".to_vec()
+}
+
+fn dec_mode_response(
+    mode: u16,
+    focus_reporting: bool,
+    alternate_screen: bool,
+    mouse_protocol_mode: vt100::MouseProtocolMode,
+    mouse_protocol_encoding: vt100::MouseProtocolEncoding,
+    bracketed_paste: bool,
+) -> Vec<u8> {
+    use vt100::{MouseProtocolEncoding, MouseProtocolMode};
+
+    let code = match mode {
+        1000 => enabled_mode_code(matches!(
+            mouse_protocol_mode,
+            MouseProtocolMode::Press
+                | MouseProtocolMode::PressRelease
+                | MouseProtocolMode::ButtonMotion
+                | MouseProtocolMode::AnyMotion
+        )),
+        1002 => enabled_mode_code(matches!(
+            mouse_protocol_mode,
+            MouseProtocolMode::ButtonMotion | MouseProtocolMode::AnyMotion
+        )),
+        1003 => enabled_mode_code(matches!(mouse_protocol_mode, MouseProtocolMode::AnyMotion)),
+        1004 => enabled_mode_code(focus_reporting),
+        1006 => enabled_mode_code(matches!(mouse_protocol_encoding, MouseProtocolEncoding::Sgr)),
+        1049 => enabled_mode_code(alternate_screen),
+        2004 => enabled_mode_code(bracketed_paste),
+        _ => 0,
+    };
+
+    format!("\x1b[?{};{}$y", mode, code).into_bytes()
+}
+
+fn enabled_mode_code(enabled: bool) -> u8 {
+    if enabled { 1 } else { 2 }
 }
 
 /// Compute the kitty keyboard protocol modifier parameter from crossterm KeyModifiers.
@@ -1120,6 +1391,62 @@ mod tests {
     #[test]
     fn test_csi_u_not_needed_for_shift_alone() {
         assert!(!needs_csi_u(KeyModifiers::SHIFT));
+    }
+
+    #[test]
+    fn test_dec_mode_detector_handles_split_sequences() {
+        let focus = AtomicBool::new(false);
+        let mut detector = FocusReportingDetector::new();
+
+        detector.process(b"\x1b[?100", &focus);
+        assert!(!focus.load(Ordering::SeqCst));
+
+        detector.process(b"4h", &focus);
+        assert!(focus.load(Ordering::SeqCst));
+
+        detector.process(b"\x1b[?1004l", &focus);
+        assert!(!focus.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_primary_device_attributes_response() {
+        assert_eq!(super::primary_device_attributes_response(), b"\x1b[?62;1;4;6;22c");
+    }
+
+    #[test]
+    fn test_secondary_device_attributes_response() {
+        assert_eq!(super::secondary_device_attributes_response(), b"\x1b[>0;10;1c");
+    }
+
+    #[test]
+    fn test_xtversion_response() {
+        assert_eq!(super::xtversion_response(), b"\x1bP>|Beehive\x1b\\");
+    }
+
+    #[test]
+    fn test_dec_mode_response_reports_enabled_focus() {
+        let bytes = super::dec_mode_response(
+            1004,
+            true,
+            false,
+            vt100::MouseProtocolMode::None,
+            vt100::MouseProtocolEncoding::Default,
+            false,
+        );
+        assert_eq!(bytes, b"\x1b[?1004;1$y");
+    }
+
+    #[test]
+    fn test_dec_mode_response_reports_unsupported_unknown_mode() {
+        let bytes = super::dec_mode_response(
+            42,
+            false,
+            false,
+            vt100::MouseProtocolMode::None,
+            vt100::MouseProtocolEncoding::Default,
+            false,
+        );
+        assert_eq!(bytes, b"\x1b[?42;0$y");
     }
 
     // --- Issue #3 keys: Cmd+A, Cmd+Right, Shift+Cmd+Right, Shift+Enter ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beehive",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beehive",
-      "version": "0.1.103",
+      "version": "0.1.104",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beehive",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "description": "Orchestrate coding agents across isolated git workspaces",
   "license": "MIT",
   "author": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -236,7 +236,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "beehive"
-version = "0.1.103"
+version = "0.1.104"
 dependencies = [
  "dirs",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beehive"
-version = "0.1.103"
+version = "0.1.104"
 description = "Orchestrate coding agents across isolated git workspaces"
 authors = ["Mykyta Storozhenko <storozhenkomykyta@gmail.com>"]
 repository = "https://github.com/storozhenko98/beehive"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Beehive",
-  "version": "0.1.103",
+  "version": "0.1.104",
   "identifier": "com.beehive.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -24,7 +24,10 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["app", "dmg"],
+    "targets": [
+      "app",
+      "dmg"
+    ],
     "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",


### PR DESCRIPTION
## Summary
- answer terminal capability and status queries in stream order so apps like Claude Code get correct mouse/scroll state
- return unsupported DECRQM modes as unsupported instead of reset
- bump release version to 0.1.104

## What this solves
This PR fixes the terminal-emulation side of scrolling in embedded CLI apps like Claude Code. The missing piece was not basic wheel-event encoding alone; these apps often probe terminal capabilities and DEC private modes before deciding whether to enable mouse and scroll behavior.

Beehive had started answering those probes, but it could answer them from the wrong state if a query and a later mode change arrived in the same PTY chunk, and it reported unsupported DEC modes as if they were supported but disabled. That made capability-detecting apps distrust the terminal state or make the wrong decision about enabling scroll behavior.

This change makes those replies accurate and ordered correctly, so apps that negotiate mouse and scroll support through terminal queries can reliably enable scrolling inside the Beehive CLI terminal.

## Verification
- cargo test --manifest-path cli/Cargo.toml