### PR TITLE
Add configurable comb startup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ curl -fsSL beehiveapp.dev/install.sh | bash
 
 You'll be asked to choose `bh` or `beehive` as your command name. Auto-updates on startup.
 
+You can also set the comb startup command programmatically from the TUI binary:
+
+```bash
+bh --startup-cmd 'tmux new-session -A -s "$(basename "$BEEHIVE_COMB")"'
+```
+
+Clear it with:
+
+```bash
+bh --startup-cmd ''
+```
+
 Or download the latest standalone TUI binary from [Releases](https://github.com/storozhenko98/beehive/releases/latest):
 
 - macOS: `beehive-tui-darwin-arm64`
@@ -37,6 +49,7 @@ Or download the latest standalone TUI binary from [Releases](https://github.com/
 - **Agent panes** — Launch Claude Code or any CLI agent alongside your terminals
 - **Copy combs** — Duplicate a workspace including uncommitted work to experiment safely
 - **Custom buttons** — Configure per-repo quick-launch buttons for your agent commands
+- **Comb startup command** — Run a configurable shell command automatically the first time each comb opens after launch
 - **Live branch tracking** — Sidebar updates when you switch branches in the terminal
 - **Layout persistence** — Pane layouts saved to disk and restored on restart
 - **Resizable sidebar** (TUI) — `<`/`>` keys to adjust, persisted across sessions
@@ -148,13 +161,23 @@ All config lives in `~/.beehive/`:
 
 | File | Purpose |
 |------|---------|
-| `~/.beehive/config.json` | App config (beehive directory path, sidebar width, CLI preferences) |
+| `~/.beehive/config.json` | App config (beehive directory path, sidebar width, CLI preferences, comb startup command) |
 | `{beehiveDir}/beehive.json` | Directory marker with version |
 | `{beehiveDir}/repo_{name}/.hive/state.json` | Hive state (repo info, combs, pane layouts, custom buttons) |
 
 Combs are full git clones at `{beehiveDir}/repo_{name}/{combName}/`.
 
 The GUI and TUI share the same config and data — you can use both interchangeably.
+
+Example startup command in `~/.beehive/config.json`:
+
+```json
+{
+  "combStartupCommand": "tmux new-session -A -s \"$(basename \"$BEEHIVE_COMB\")\""
+}
+```
+
+Beehive runs that command once per comb the first time it opens that comb after launch, then returns to an interactive shell in the comb directory.
 
 ## Platform Support
 

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -226,8 +226,10 @@ pub struct App {
     pub pending_refresh: Option<Arc<Mutex<Option<RefreshResult>>>>,
     pub update_available: Option<String>,
     pub sidebar_width: u16,
+    pub comb_startup_command: Option<String>,
     pub deleting_comb_ids: HashSet<String>,
     pub deleting_hive_dir_names: HashSet<String>,
+    pub startup_applied_comb_ids: HashSet<String>,
     /// Whether the outer terminal supports the kitty keyboard enhancement protocol.
     /// When true, crossterm reports SUPER/META modifiers and key event kinds (press/repeat/release).
     pub keyboard_enhanced: bool,
@@ -650,8 +652,12 @@ impl App {
             pending_refresh: None,
             update_available: None,
             sidebar_width: config.sidebar_width,
+            comb_startup_command: config
+                .comb_startup_command
+                .filter(|cmd| !cmd.trim().is_empty()),
             deleting_comb_ids: HashSet::new(),
             deleting_hive_dir_names: HashSet::new(),
+            startup_applied_comb_ids: HashSet::new(),
             keyboard_enhanced,
             needs_refresh: false,
         };
@@ -826,8 +832,24 @@ impl App {
         let term_cols = (cols * 70 / 100).max(20);
         let term_rows = rows.saturating_sub(3).max(5);
 
-        match EmbeddedTerminal::new(comb_path, term_rows, term_cols, self.keyboard_enhanced) {
+        let should_run_startup = !self.startup_applied_comb_ids.contains(comb_id);
+        let startup_command = if should_run_startup {
+            self.comb_startup_command.as_deref()
+        } else {
+            None
+        };
+
+        match EmbeddedTerminal::new(
+            comb_path,
+            term_rows,
+            term_cols,
+            self.keyboard_enhanced,
+            startup_command,
+        ) {
             Ok(term) => {
+                if startup_command.is_some() {
+                    self.startup_applied_comb_ids.insert(comb_id.to_string());
+                }
                 self.terminals.insert(comb_id.to_string(), term);
                 self.focus = Focus::Terminal;
                 self.last_term_size = (0, 0);
@@ -1188,8 +1210,10 @@ mod tests {
             pending_refresh: None,
             update_available: None,
             sidebar_width: 28,
+            comb_startup_command: None,
             deleting_comb_ids: HashSet::new(),
             deleting_hive_dir_names: HashSet::new(),
+            startup_applied_comb_ids: HashSet::new(),
             keyboard_enhanced: false,
             needs_refresh: false,
         }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -1,0 +1,206 @@
+use std::error::Error;
+
+use crate::config::{load_app_config, save_app_config};
+
+#[derive(Debug, PartialEq, Eq)]
+enum CliAction {
+    RunApp,
+    PrintHelp(String),
+    SetStartupCommand(String),
+    ClearStartupCommand,
+}
+
+pub enum CommandResult {
+    ContinueToApp,
+    Exit,
+}
+
+pub fn handle_cli_args<I>(args: I) -> Result<CommandResult, Box<dyn Error>>
+where
+    I: IntoIterator<Item = String>,
+{
+    execute_cli_action(parse_cli_action(args)?)
+}
+
+fn execute_cli_action(action: CliAction) -> Result<CommandResult, Box<dyn Error>> {
+    match action {
+        CliAction::RunApp => Ok(CommandResult::ContinueToApp),
+        CliAction::PrintHelp(help) => {
+            print!("{}", help);
+            Ok(CommandResult::Exit)
+        }
+        CliAction::SetStartupCommand(command) => {
+            save_startup_command(Some(command))?;
+            Ok(CommandResult::Exit)
+        }
+        CliAction::ClearStartupCommand => {
+            save_startup_command(None)?;
+            Ok(CommandResult::Exit)
+        }
+    }
+}
+
+fn cli_help(bin: &str) -> String {
+    format!(
+        "\
+Beehive TUI
+
+Usage:
+  {bin}
+  {bin} --startup-cmd \"<command>\"
+  {bin} --startup-cmd ''
+  {bin} --help
+
+Options:
+  --startup-cmd <command>  Save the comb startup command in ~/.beehive/config.json
+                           Runs once per comb when that comb first opens after launch
+                           Pass an empty string to clear it
+  -h, --help               Show this help text
+"
+    )
+}
+
+fn parse_cli_action<I>(args: I) -> Result<CliAction, Box<dyn Error>>
+where
+    I: IntoIterator<Item = String>,
+{
+    let mut args = args.into_iter();
+    let bin = args.next().unwrap_or_else(|| "beehive".to_string());
+    let mut action = CliAction::RunApp;
+
+    while let Some(arg) = args.next() {
+        if arg == "--help" || arg == "-h" {
+            return Ok(CliAction::PrintHelp(cli_help(&bin)));
+        }
+
+        if arg == "--startup-cmd" {
+            let value = args.next().ok_or_else(|| {
+                format!(
+                    "Missing value for --startup-cmd\nUsage: {} --startup-cmd \"<command>\"",
+                    bin
+                )
+            })?;
+            action = startup_command_action(value);
+            continue;
+        }
+
+        if let Some(value) = arg.strip_prefix("--startup-cmd=") {
+            action = startup_command_action(value.to_string());
+            continue;
+        }
+
+        return Err(format!("Unknown argument '{}'\n\n{}", arg, cli_help(&bin)).into());
+    }
+
+    Ok(action)
+}
+
+fn startup_command_action(value: String) -> CliAction {
+    if value.trim().is_empty() {
+        CliAction::ClearStartupCommand
+    } else {
+        CliAction::SetStartupCommand(value)
+    }
+}
+
+fn save_startup_command(command: Option<String>) -> Result<(), Box<dyn Error>> {
+    let mut config = load_app_config().map_err(|e| -> Box<dyn Error> { e.into() })?;
+    config.comb_startup_command = command;
+    save_app_config(&config).map_err(|e| -> Box<dyn Error> { e.into() })?;
+
+    match config.comb_startup_command.as_deref() {
+        Some(command) => println!("Saved comb startup command: {}", command),
+        None => println!("Cleared comb startup command"),
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_cli_action_defaults_to_running_app() {
+        let action = parse_cli_action(vec!["bh".to_string()]).unwrap();
+        assert_eq!(action, CliAction::RunApp);
+    }
+
+    #[test]
+    fn parse_cli_action_accepts_help_flag() {
+        let action = parse_cli_action(vec!["bh".to_string(), "--help".to_string()]).unwrap();
+
+        match action {
+            CliAction::PrintHelp(help) => {
+                assert!(help.contains("Usage:"));
+                assert!(help.contains("--startup-cmd"));
+            }
+            _ => panic!("expected help action"),
+        }
+    }
+
+    #[test]
+    fn parse_cli_action_accepts_short_help_flag() {
+        let action = parse_cli_action(vec!["bh".to_string(), "-h".to_string()]).unwrap();
+
+        match action {
+            CliAction::PrintHelp(help) => assert!(help.contains("Beehive TUI")),
+            _ => panic!("expected help action"),
+        }
+    }
+
+    #[test]
+    fn parse_cli_action_accepts_startup_command_flag() {
+        let action = parse_cli_action(vec![
+            "bh".to_string(),
+            "--startup-cmd".to_string(),
+            "tmux new-session -A -s dev".to_string(),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            action,
+            CliAction::SetStartupCommand("tmux new-session -A -s dev".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_cli_action_accepts_equals_form() {
+        let action = parse_cli_action(vec![
+            "bh".to_string(),
+            "--startup-cmd=tmux new-session -A -s dev".to_string(),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            action,
+            CliAction::SetStartupCommand("tmux new-session -A -s dev".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_cli_action_treats_empty_command_as_clear() {
+        let action = parse_cli_action(vec![
+            "bh".to_string(),
+            "--startup-cmd".to_string(),
+            "".to_string(),
+        ])
+        .unwrap();
+
+        assert_eq!(action, CliAction::ClearStartupCommand);
+    }
+
+    #[test]
+    fn parse_cli_action_rejects_missing_startup_command_value() {
+        let err =
+            parse_cli_action(vec!["bh".to_string(), "--startup-cmd".to_string()]).unwrap_err();
+        assert!(err.to_string().contains("Missing value for --startup-cmd"));
+    }
+
+    #[test]
+    fn parse_cli_action_unknown_argument_includes_help() {
+        let err = parse_cli_action(vec!["bh".to_string(), "--wat".to_string()]).unwrap_err();
+        assert!(err.to_string().contains("Unknown argument '--wat'"));
+        assert!(err.to_string().contains("--help"));
+    }
+}

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -13,6 +13,8 @@ pub struct AppConfig {
     pub mux_preference: Option<String>,
     #[serde(default)]
     pub cli_command: Option<String>,
+    #[serde(default)]
+    pub comb_startup_command: Option<String>,
     #[serde(default = "default_sidebar_width")]
     pub sidebar_width: u16,
 }
@@ -162,6 +164,7 @@ pub fn load_app_config() -> Result<AppConfig, String> {
             beehive_dir: None,
             mux_preference: None,
             cli_command: None,
+            comb_startup_command: None,
             sidebar_width: 28,
         });
     }
@@ -531,7 +534,6 @@ mod tests {
 
         let _ = fs::remove_dir_all(&beehive_dir);
     }
-
     #[test]
     fn renamed_comb_reserves_original_directory_name() {
         let beehive_dir = unique_temp_dir();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,5 @@
 mod app;
+mod commands;
 mod config;
 mod fuzzy;
 mod keyboard;
@@ -26,6 +27,7 @@ use app::{
     App, AppMode, CloneResult, ConfirmAction, DeleteResult, DeleteTarget, Focus, InputAction,
     RefreshResult,
 };
+use commands::{handle_cli_args, CommandResult};
 use config::*;
 
 type Term = Terminal<CrosstermBackend<io::Stdout>>;
@@ -38,6 +40,10 @@ fn main() {
 }
 
 fn run() -> Result<(), Box<dyn std::error::Error>> {
+    if matches!(handle_cli_args(std::env::args())?, CommandResult::Exit) {
+        return Ok(());
+    }
+
     // Preflight checks before entering TUI
     let pf = preflight();
     if pf.git.is_none() {
@@ -160,6 +166,7 @@ fn ensure_config() -> Result<String, Box<dyn std::error::Error>> {
         beehive_dir: Some(dir.clone()),
         mux_preference: None,
         cli_command: None,
+        comb_startup_command: None,
         sidebar_width: 28,
     })
     .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
@@ -1519,8 +1526,10 @@ mod tests {
             pending_refresh: None,
             update_available: None,
             sidebar_width: 28,
+            comb_startup_command: None,
             deleting_comb_ids: HashSet::new(),
             deleting_hive_dir_names: HashSet::new(),
+            startup_applied_comb_ids: HashSet::new(),
             keyboard_enhanced: false,
             needs_refresh: false,
         }

--- a/cli/src/terminal.rs
+++ b/cli/src/terminal.rs
@@ -131,6 +131,17 @@ fn resolve_login_shell() -> String {
     resolve_login_shell_with_candidates(shell_env.as_deref(), &["/bin/bash", "/bin/sh"])
 }
 
+fn normalize_startup_command(startup_command: Option<&str>) -> Option<&str> {
+    startup_command.and_then(|cmd| {
+        let trimmed = cmd.trim();
+        (!trimmed.is_empty()).then_some(trimmed)
+    })
+}
+
+fn startup_wrapper_script() -> &'static str {
+    "eval \"$BEEHIVE_STARTUP_COMMAND\"\nexec \"$SHELL\" -l"
+}
+
 pub struct EmbeddedTerminal {
     /// vt100 parser — owned exclusively by the main thread (no locks needed).
     /// Background reader sends raw bytes via `output_rx` channel instead.
@@ -160,6 +171,7 @@ impl EmbeddedTerminal {
         rows: u16,
         cols: u16,
         outer_keyboard_enhanced: bool,
+        startup_command: Option<&str>,
     ) -> Result<Self, String> {
         let pty_system = native_pty_system();
 
@@ -174,10 +186,18 @@ impl EmbeddedTerminal {
 
         let shell = resolve_login_shell();
         let mut cmd = CommandBuilder::new(&shell);
-        cmd.arg("-l");
+        if let Some(startup_command) = normalize_startup_command(startup_command) {
+            cmd.arg("-lc");
+            cmd.arg(startup_wrapper_script());
+            cmd.env("SHELL", &shell);
+            cmd.env("BEEHIVE_STARTUP_COMMAND", startup_command);
+        } else {
+            cmd.arg("-l");
+        }
         cmd.cwd(cwd);
         cmd.env("TERM", "xterm-256color");
         cmd.env("PATH", full_path());
+        cmd.env("SHELL", &shell);
         cmd.env("BEEHIVE_COMB", cwd);
 
         let child = pair

--- a/src-tauri/src/hive.rs
+++ b/src-tauri/src/hive.rs
@@ -203,7 +203,17 @@ pub async fn preflight_check() -> Result<PreflightResult, String> {
 pub struct AppConfig {
     pub beehive_dir: Option<String>,
     #[serde(default)]
+    pub mux_preference: Option<String>,
+    #[serde(default)]
     pub cli_command: Option<String>,
+    #[serde(default)]
+    pub comb_startup_command: Option<String>,
+    #[serde(default = "default_sidebar_width")]
+    pub sidebar_width: u16,
+}
+
+fn default_sidebar_width() -> u16 {
+    28
 }
 
 fn app_config_path() -> std::path::PathBuf {
@@ -224,7 +234,13 @@ pub async fn get_home_dir() -> Result<String, String> {
 pub async fn load_app_config() -> Result<AppConfig, String> {
     let path = app_config_path();
     if !path.exists() {
-        return Ok(AppConfig { beehive_dir: None, cli_command: None });
+        return Ok(AppConfig {
+            beehive_dir: None,
+            mux_preference: None,
+            cli_command: None,
+            comb_startup_command: None,
+            sidebar_width: default_sidebar_width(),
+        });
     }
     let data = fs::read_to_string(&path)
         .map_err(|e| format!("Failed to read app config: {}", e))?;

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{Read, Write};
 use std::sync::Arc;
 
@@ -14,17 +14,40 @@ pub struct PtySession {
 
 pub struct PtyManager {
     pub sessions: HashMap<String, PtySession>,
+    pub startup_initialized_combs: HashSet<String>,
 }
 
 impl PtyManager {
     pub fn new() -> Self {
         Self {
             sessions: HashMap::new(),
+            startup_initialized_combs: HashSet::new(),
         }
     }
 }
 
 pub type PtyState = Arc<Mutex<PtyManager>>;
+
+fn resolve_login_shell() -> String {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+    let trimmed = shell.trim();
+    if trimmed.is_empty() {
+        "/bin/zsh".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn normalize_startup_command(startup_command: Option<&str>) -> Option<&str> {
+    startup_command.and_then(|cmd| {
+        let trimmed = cmd.trim();
+        (!trimmed.is_empty()).then_some(trimmed)
+    })
+}
+
+fn startup_wrapper_script() -> &'static str {
+    "eval \"$BEEHIVE_STARTUP_COMMAND\"\nexec \"$SHELL\" -l"
+}
 
 #[tauri::command]
 pub async fn create_pty(
@@ -38,6 +61,24 @@ pub async fn create_pty(
     state: State<'_, PtyState>,
 ) -> Result<(), String> {
     let pty_system = native_pty_system();
+
+    let startup_command = if cmd.is_none() {
+        let config = crate::hive::load_app_config().await?;
+        normalize_startup_command(config.comb_startup_command.as_deref()).map(str::to_string)
+    } else {
+        None
+    };
+
+    let startup_command = if let Some(startup_command) = startup_command {
+        let manager = state.lock().await;
+        if manager.startup_initialized_combs.contains(&cwd) {
+            None
+        } else {
+            Some(startup_command)
+        }
+    } else {
+        None
+    };
 
     let pair = pty_system
         .openpty(PtySize {
@@ -59,9 +100,15 @@ pub async fn create_pty(
             cb
         }
         None => {
-            // Default to user's shell
-            let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
-            CommandBuilder::new(shell)
+            let shell = resolve_login_shell();
+            let mut cb = CommandBuilder::new(&shell);
+            if let Some(startup_command) = startup_command.as_deref() {
+                cb.arg("-lc");
+                cb.arg(startup_wrapper_script());
+                cb.env("SHELL", &shell);
+                cb.env("BEEHIVE_STARTUP_COMMAND", startup_command);
+            }
+            cb
         }
     };
 
@@ -78,6 +125,7 @@ pub async fn create_pty(
         }
     }
     command.env("PATH", parts.join(":"));
+    command.env("BEEHIVE_COMB", &cwd);
 
     let child = pair
         .slave
@@ -99,6 +147,9 @@ pub async fn create_pty(
 
     {
         let mut manager = state.lock().await;
+        if startup_command.is_some() {
+            manager.startup_initialized_combs.insert(cwd.clone());
+        }
         manager.sessions.insert(
             id.clone(),
             PtySession {
@@ -232,4 +283,23 @@ pub async fn close_pty(id: String, state: State<'_, PtyState>) -> Result<(), Str
         session.child.kill().ok();
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalize_startup_command, startup_wrapper_script};
+
+    #[test]
+    fn normalize_startup_command_ignores_blank_values() {
+        assert_eq!(normalize_startup_command(None), None);
+        assert_eq!(normalize_startup_command(Some("")), None);
+        assert_eq!(normalize_startup_command(Some("   ")), None);
+    }
+
+    #[test]
+    fn startup_wrapper_returns_to_shell_after_command() {
+        let script = startup_wrapper_script();
+        assert!(script.contains("BEEHIVE_STARTUP_COMMAND"));
+        assert!(script.contains("exec \"$SHELL\" -l"));
+    }
 }

--- a/src/components/SettingsScreen.tsx
+++ b/src/components/SettingsScreen.tsx
@@ -13,6 +13,14 @@ interface PreflightResult {
   messages: string[];
 }
 
+interface AppConfig {
+  beehiveDir: string | null;
+  muxPreference?: string | null;
+  cliCommand?: string | null;
+  combStartupCommand?: string | null;
+  sidebarWidth?: number;
+}
+
 interface Props {
   beehiveDir: string;
   onBack: () => void;
@@ -37,6 +45,11 @@ export function SettingsScreen({ beehiveDir, onBack, onReset, backLabel }: Props
   const [updateInfo, setUpdateInfo] = useState<Update | null>(null);
   const [updateError, setUpdateError] = useState("");
   const [downloadProgress, setDownloadProgress] = useState(0);
+  const [appConfig, setAppConfig] = useState<AppConfig | null>(null);
+  const [combStartupCommand, setCombStartupCommand] = useState("");
+  const [startupSaving, setStartupSaving] = useState(false);
+  const [startupError, setStartupError] = useState("");
+  const [startupSaved, setStartupSaved] = useState(false);
 
   const checkForUpdates = useCallback(async () => {
     setUpdateStatus("checking");
@@ -58,10 +71,36 @@ export function SettingsScreen({ beehiveDir, onBack, onReset, backLabel }: Props
   useEffect(() => {
     invoke<string>("get_app_config_path").then(setConfigPath);
     invoke<PreflightResult>("preflight_check").then(setPreflight);
+    invoke<AppConfig>("load_app_config").then((config) => {
+      setAppConfig(config);
+      setCombStartupCommand(config.combStartupCommand ?? "");
+    });
     getVersion().then(setAppVersion);
     checkCli();
     checkForUpdates();
   }, [checkForUpdates]);
+
+  async function handleSaveStartupCommand() {
+    setStartupSaving(true);
+    setStartupError("");
+    setStartupSaved(false);
+
+    const trimmed = combStartupCommand.trim();
+    const nextConfig: AppConfig = appConfig
+      ? { ...appConfig, combStartupCommand: trimmed || null }
+      : { beehiveDir, combStartupCommand: trimmed || null };
+
+    try {
+      await invoke("save_app_config", { config: nextConfig });
+      setAppConfig(nextConfig);
+      setCombStartupCommand(trimmed);
+      setStartupSaved(true);
+    } catch (e) {
+      setStartupError(`${e}`);
+    }
+
+    setStartupSaving(false);
+  }
 
   async function checkCli() {
     try {
@@ -224,6 +263,55 @@ export function SettingsScreen({ beehiveDir, onBack, onReset, backLabel }: Props
               </button>
             </>
           )}
+        </div>
+
+        <div className="settings-section">
+          <h3>Comb startup</h3>
+          <p style={{ color: "var(--text-secondary)", fontSize: 12, marginBottom: 8 }}>
+            Runs once per comb when Beehive opens that comb for the first time after launch, then drops into an interactive shell.
+          </p>
+          <input
+            type="text"
+            value={combStartupCommand}
+            onChange={(e) => {
+              setCombStartupCommand(e.target.value);
+              setStartupSaved(false);
+              if (startupError) setStartupError("");
+            }}
+            placeholder='e.g. tmux new-session -A -s "$(basename "$BEEHIVE_COMB")"'
+            spellCheck={false}
+            style={{ width: "100%", marginBottom: 8 }}
+          />
+          <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+            <button
+              className="btn btn-primary"
+              onClick={handleSaveStartupCommand}
+              disabled={startupSaving}
+            >
+              {startupSaving ? "Saving..." : "Save startup command"}
+            </button>
+            {combStartupCommand && (
+              <button
+                className="btn btn-secondary"
+                onClick={() => {
+                  setCombStartupCommand("");
+                  setStartupSaved(false);
+                }}
+                disabled={startupSaving}
+              >
+                Clear
+              </button>
+            )}
+            {startupSaved && (
+              <span style={{ color: "var(--success)", fontSize: 12 }}>
+                Saved
+              </span>
+            )}
+          </div>
+          <p style={{ color: "var(--text-muted)", fontSize: 11, marginTop: 6 }}>
+            Available in the shell as <code>BEEHIVE_COMB</code>.
+          </p>
+          {startupError && <div className="error-box" style={{ marginTop: 6 }}>{startupError}</div>}
         </div>
 
         <div className="settings-section">


### PR DESCRIPTION
## Summary
- add a shared `combStartupCommand` app config used by both the desktop GUI and the TUI
- run that command automatically the first time a comb opens after Beehive launches, then hand control back to an interactive login shell in that comb
- add configuration surfaces for the feature in the GUI settings screen, the TUI CLI (`--startup-cmd`), the README, and `bh --help`

## Behavior
- the startup command is stored in `~/.beehive/config.json`, so GUI and TUI use the same setting
- Beehive exports `BEEHIVE_COMB` to the startup command so scripts can key off the comb path
- startup execution is gated to shell-backed comb panes only and runs once per comb per app launch to avoid spawning duplicate `tmux` or agent sessions when opening extra panes
- the comb is only marked as initialized after PTY creation succeeds, so failed startup attempts can retry instead of being suppressed for the rest of the session
- `bh --startup-cmd ''` clears the saved command

## Implementation Notes
- split TUI command parsing and execution into `cli/src/commands.rs` so `main.rs` stays focused on app startup
- add the startup wrapper to both PTY implementations so shell panes in the GUI and TUI behave the same way
- simplify the settings save path so it updates `combStartupCommand` on the loaded app config rather than rebuilding the full config object

## Example
```bash
bh --startup-cmd 'tmux new-session -A -s "$(basename "$BEEHIVE_COMB")" "claude --continue || claude"'
```

## Verification
- `cargo test` in `cli/`
- `cargo test` in `src-tauri/`
- `npm run build`
