### PR TITLE
Add fresh hives and OpenCode attention

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -1,9 +1,176 @@
 use std::collections::{HashMap, HashSet};
+use std::io::{BufRead, BufReader, Write};
+use std::net::{TcpListener, TcpStream};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use crate::config::*;
 use crate::fuzzy::fuzzy_match_score;
 use crate::terminal::EmbeddedTerminal;
+use serde_json::Value;
+
+#[derive(Clone)]
+pub enum OpenCodeAttentionKind {
+    Input,
+    Idle,
+    Error,
+    Clear,
+    Stopped,
+}
+
+#[derive(Clone)]
+pub struct OpenCodeAttentionEvent {
+    pub comb_id: String,
+    pub kind: OpenCodeAttentionKind,
+}
+
+fn reserve_local_port() -> Result<u16, String> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .map_err(|e| format!("Failed to reserve OpenCode port: {}", e))?;
+    let port = listener
+        .local_addr()
+        .map_err(|e| format!("Failed to read OpenCode port: {}", e))?
+        .port();
+    drop(listener);
+    Ok(port)
+}
+
+fn json_event_type(data: &str) -> Option<String> {
+    let value: Value = serde_json::from_str(data).ok()?;
+    value
+        .get("type")
+        .or_else(|| value.get("name"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn classify_opencode_event(event_type: &str, data: &str) -> Option<OpenCodeAttentionKind> {
+    match event_type {
+        "permission.asked" | "question.asked" => Some(OpenCodeAttentionKind::Input),
+        "permission.replied" | "question.replied" | "question.rejected" => {
+            Some(OpenCodeAttentionKind::Clear)
+        }
+        "session.error" => Some(OpenCodeAttentionKind::Error),
+        "session.idle" => Some(OpenCodeAttentionKind::Idle),
+        "session.status" => {
+            let value: Value = serde_json::from_str(data).ok()?;
+            let status_type = value
+                .pointer("/properties/status/type")
+                .or_else(|| value.pointer("/status/type"))
+                .and_then(Value::as_str);
+            match status_type {
+                Some("idle") => Some(OpenCodeAttentionKind::Idle),
+                Some("busy") | Some("retry") => Some(OpenCodeAttentionKind::Clear),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn push_opencode_event(
+    events: &Arc<Mutex<Vec<OpenCodeAttentionEvent>>>,
+    comb_id: &str,
+    kind: OpenCodeAttentionKind,
+) {
+    if let Ok(mut guard) = events.lock() {
+        guard.push(OpenCodeAttentionEvent {
+            comb_id: comb_id.to_string(),
+            kind,
+        });
+    }
+}
+
+fn start_opencode_event_listener(
+    comb_id: String,
+    port: u16,
+    events: Arc<Mutex<Vec<OpenCodeAttentionEvent>>>,
+) {
+    std::thread::spawn(move || {
+        let mut stream = None;
+        for _ in 0..300 {
+            match TcpStream::connect(("127.0.0.1", port)) {
+                Ok(s) => {
+                    stream = Some(s);
+                    break;
+                }
+                Err(_) => std::thread::sleep(Duration::from_millis(100)),
+            }
+        }
+
+        let Some(mut stream) = stream else {
+            push_opencode_event(&events, &comb_id, OpenCodeAttentionKind::Error);
+            push_opencode_event(&events, &comb_id, OpenCodeAttentionKind::Stopped);
+            return;
+        };
+
+        let request = format!(
+            "GET /event HTTP/1.1\r\nHost: 127.0.0.1:{}\r\nAccept: text/event-stream\r\nConnection: close\r\n\r\n",
+            port
+        );
+        if stream.write_all(request.as_bytes()).is_err() {
+            push_opencode_event(&events, &comb_id, OpenCodeAttentionKind::Error);
+            push_opencode_event(&events, &comb_id, OpenCodeAttentionKind::Stopped);
+            return;
+        }
+
+        let mut reader = BufReader::new(stream);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => {
+                    push_opencode_event(&events, &comb_id, OpenCodeAttentionKind::Stopped);
+                    return;
+                }
+                Ok(_) if line == "\r\n" || line == "\n" => break,
+                Ok(_) => continue,
+                Err(_) => {
+                    push_opencode_event(&events, &comb_id, OpenCodeAttentionKind::Stopped);
+                    return;
+                }
+            }
+        }
+
+        let mut event_name: Option<String> = None;
+        let mut data = String::new();
+        loop {
+            line.clear();
+            let read = match reader.read_line(&mut line) {
+                Ok(read) => read,
+                Err(_) => {
+                    push_opencode_event(&events, &comb_id, OpenCodeAttentionKind::Stopped);
+                    return;
+                }
+            };
+            if read == 0 {
+                push_opencode_event(&events, &comb_id, OpenCodeAttentionKind::Stopped);
+                return;
+            }
+
+            let trimmed = line.trim_end_matches(['\r', '\n']);
+            if trimmed.is_empty() {
+                if !data.is_empty() {
+                    let event_type = event_name.clone().or_else(|| json_event_type(&data));
+                    if let Some(event_type) = event_type {
+                        if let Some(kind) = classify_opencode_event(&event_type, &data) {
+                            push_opencode_event(&events, &comb_id, kind);
+                        }
+                    }
+                }
+                event_name = None;
+                data.clear();
+            } else if let Some(value) = trimmed.strip_prefix("event:") {
+                event_name = Some(value.trim().to_string());
+            } else if let Some(value) = trimmed.strip_prefix("data:") {
+                if !data.is_empty() {
+                    data.push('\n');
+                }
+                data.push_str(value.trim_start());
+            }
+        }
+    });
+}
 
 /// Background clone result.
 pub struct CloneResult {
@@ -291,6 +458,9 @@ pub struct App {
     pub active_comb_id: Option<String>,
     pub focus: Focus,
     pub terminals: HashMap<String, EmbeddedTerminal>,
+    pub opencode_terminal_ids: HashSet<String>,
+    pub opencode_attention: HashMap<String, OpenCodeAttentionKind>,
+    pub opencode_attention_events: Arc<Mutex<Vec<OpenCodeAttentionEvent>>>,
     pub last_term_size: (u16, u16),
     /// Multiple concurrent clone/copy operations
     pub pending_clones: Vec<PendingClone>,
@@ -933,6 +1103,9 @@ impl App {
             active_comb_id: None,
             focus: Focus::Sidebar,
             terminals: HashMap::new(),
+            opencode_terminal_ids: HashSet::new(),
+            opencode_attention: HashMap::new(),
+            opencode_attention_events: Arc::new(Mutex::new(Vec::new())),
             last_term_size: (0, 0),
             pending_clones: Vec::new(),
             pending_deletes: Vec::new(),
@@ -1166,7 +1339,9 @@ impl App {
 
     /// Switch to or create a terminal for the given comb.
     pub fn open_terminal(&mut self, comb_id: &str, comb_path: &str) {
+        self.opencode_attention.remove(comb_id);
         if self.terminals.contains_key(comb_id) {
+            self.active_comb_id = Some(comb_id.to_string());
             self.focus = Focus::Terminal;
             self.last_term_size = (0, 0);
             return;
@@ -1189,12 +1364,15 @@ impl App {
             term_cols,
             self.keyboard_enhanced,
             startup_command,
+            None,
         ) {
             Ok(term) => {
                 if startup_command.is_some() {
                     self.startup_applied_comb_ids.insert(comb_id.to_string());
                 }
+                self.opencode_terminal_ids.remove(comb_id);
                 self.terminals.insert(comb_id.to_string(), term);
+                self.active_comb_id = Some(comb_id.to_string());
                 self.focus = Focus::Terminal;
                 self.last_term_size = (0, 0);
             }
@@ -1202,6 +1380,166 @@ impl App {
                 self.status_message = Some(format!("Terminal: {}", e));
             }
         }
+    }
+
+    pub fn open_opencode_terminal(&mut self, comb_id: &str, comb_path: &str) {
+        self.opencode_attention.remove(comb_id);
+        if self
+            .terminals
+            .get(comb_id)
+            .map(|term| !term.is_alive())
+            .unwrap_or(false)
+        {
+            self.terminals.remove(comb_id);
+            self.opencode_terminal_ids.remove(comb_id);
+        }
+
+        if self.opencode_terminal_ids.contains(comb_id) {
+            self.active_comb_id = Some(comb_id.to_string());
+            self.focus = Focus::Terminal;
+            self.last_term_size = (0, 0);
+            return;
+        }
+
+        let port = match reserve_local_port() {
+            Ok(port) => port,
+            Err(e) => {
+                self.status_message = Some(e);
+                return;
+            }
+        };
+
+        if let Some(term) = self.terminals.get(comb_id) {
+            start_opencode_event_listener(
+                comb_id.to_string(),
+                port,
+                Arc::clone(&self.opencode_attention_events),
+            );
+            let command = format!("opencode --hostname 127.0.0.1 --port {}\r", port);
+            term.write_input(command.as_bytes());
+            self.opencode_terminal_ids.insert(comb_id.to_string());
+            self.active_comb_id = Some(comb_id.to_string());
+            self.focus = Focus::Terminal;
+            self.last_term_size = (0, 0);
+            self.status_message = Some("Sent OpenCode command to existing terminal".to_string());
+            return;
+        }
+
+        let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));
+        let term_cols = (cols * 70 / 100).max(20);
+        let term_rows = rows.saturating_sub(3).max(5);
+
+        match EmbeddedTerminal::new(
+            comb_path,
+            term_rows,
+            term_cols,
+            self.keyboard_enhanced,
+            None,
+            Some(port),
+        ) {
+            Ok(term) => {
+                start_opencode_event_listener(
+                    comb_id.to_string(),
+                    port,
+                    Arc::clone(&self.opencode_attention_events),
+                );
+                self.opencode_terminal_ids.insert(comb_id.to_string());
+                self.terminals.insert(comb_id.to_string(), term);
+                self.active_comb_id = Some(comb_id.to_string());
+                self.focus = Focus::Terminal;
+                self.last_term_size = (0, 0);
+            }
+            Err(e) => {
+                self.status_message = Some(format!("OpenCode: {}", e));
+            }
+        }
+    }
+
+    pub fn selected_comb_target(&self) -> Option<(String, String)> {
+        if self.items.is_empty() {
+            return None;
+        }
+        match &self.items[self.selected] {
+            NavItem::Comb { comb, .. } if !comb.cloning => {
+                Some((comb.id.clone(), comb.path.clone()))
+            }
+            _ => None,
+        }
+    }
+
+    pub fn drain_opencode_attention(&mut self) -> bool {
+        let stale_opencode_ids = self
+            .opencode_terminal_ids
+            .iter()
+            .filter(|id| {
+                self.terminals
+                    .get(*id)
+                    .map(|term| !term.is_alive())
+                    .unwrap_or(true)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut changed = false;
+        for id in stale_opencode_ids {
+            self.opencode_terminal_ids.remove(&id);
+            self.opencode_attention.remove(&id);
+            if self
+                .terminals
+                .get(&id)
+                .map(|term| !term.is_alive())
+                .unwrap_or(false)
+            {
+                self.terminals.remove(&id);
+                if self.active_comb_id.as_deref() == Some(id.as_str()) {
+                    self.active_comb_id = None;
+                    self.focus = Focus::Sidebar;
+                    self.last_term_size = (0, 0);
+                }
+            }
+            changed = true;
+        }
+
+        let events = {
+            let Ok(mut guard) = self.opencode_attention_events.try_lock() else {
+                return changed;
+            };
+            if guard.is_empty() {
+                return changed;
+            }
+            guard.drain(..).collect::<Vec<_>>()
+        };
+
+        for event in events {
+            match event.kind {
+                OpenCodeAttentionKind::Stopped => {
+                    self.opencode_terminal_ids.remove(&event.comb_id);
+                    if self
+                        .terminals
+                        .get(&event.comb_id)
+                        .map(|term| !term.is_alive())
+                        .unwrap_or(false)
+                    {
+                        self.terminals.remove(&event.comb_id);
+                        if self.active_comb_id.as_deref() == Some(event.comb_id.as_str()) {
+                            self.active_comb_id = None;
+                            self.focus = Focus::Sidebar;
+                            self.last_term_size = (0, 0);
+                        }
+                    }
+                }
+                OpenCodeAttentionKind::Clear => {
+                    self.opencode_attention.remove(&event.comb_id);
+                }
+                kind => {
+                    if self.active_comb_id.as_deref() == Some(event.comb_id.as_str()) {
+                        self.opencode_attention.remove(&event.comb_id);
+                    } else {
+                        self.opencode_attention.insert(event.comb_id, kind);
+                    }
+                }
+            }
+        }
+        true
     }
 
     pub fn active_terminal(&self) -> Option<&EmbeddedTerminal> {
@@ -1230,6 +1568,8 @@ impl App {
 
     pub fn remove_terminal(&mut self, comb_id: &str) {
         self.terminals.remove(comb_id);
+        self.opencode_terminal_ids.remove(comb_id);
+        self.opencode_attention.remove(comb_id);
         if self.active_comb_id.as_deref() == Some(comb_id) {
             self.active_comb_id = None;
             self.focus = Focus::Sidebar;
@@ -1250,6 +1590,8 @@ impl App {
             .collect();
         for id in &ids_to_remove {
             self.terminals.remove(id);
+            self.opencode_terminal_ids.remove(id);
+            self.opencode_attention.remove(id);
         }
         if let Some(active) = &self.active_comb_id {
             if ids_to_remove.contains(active) {
@@ -1699,6 +2041,9 @@ mod tests {
             active_comb_id: None,
             focus: Focus::Sidebar,
             terminals: HashMap::new(),
+            opencode_terminal_ids: HashSet::new(),
+            opencode_attention: HashMap::new(),
+            opencode_attention_events: Arc::new(Mutex::new(Vec::new())),
             last_term_size: (0, 0),
             pending_clones: Vec::new(),
             pending_deletes: Vec::new(),

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -1467,6 +1467,17 @@ impl App {
         }
     }
 
+    pub fn restart_comb_terminal(&mut self, comb_id: &str, comb_path: &str) {
+        self.terminals.remove(comb_id);
+        self.opencode_terminal_ids.remove(comb_id);
+        self.opencode_attention.remove(comb_id);
+        self.startup_applied_comb_ids.remove(comb_id);
+        self.open_terminal(comb_id, comb_path);
+        if self.status_message.is_none() {
+            self.status_message = Some("Restarted comb terminal".to_string());
+        }
+    }
+
     pub fn drain_opencode_attention(&mut self) -> bool {
         let stale_opencode_ids = self
             .opencode_terminal_ids

--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -193,6 +193,7 @@ pub enum InputAction {
         hive_dir_name: String,
     },
     AddHiveUrl,
+    CreateFreshHiveRepo,
     RenameSelected {
         target: RenameTarget,
     },
@@ -1555,6 +1556,15 @@ impl App {
             value: String::new(),
             cursor: 0,
             action: InputAction::AddHiveUrl,
+        });
+    }
+
+    pub fn start_create_fresh_hive(&mut self) {
+        self.enter_sidebar_mode(AppMode::Input {
+            prompt: "New private repo (repo or owner/repo)".to_string(),
+            value: String::new(),
+            cursor: 0,
+            action: InputAction::CreateFreshHiveRepo,
         });
     }
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -261,6 +261,326 @@ pub fn list_hives(beehive_dir: &str) -> Result<Vec<HiveInfo>, String> {
     Ok(hives)
 }
 
+pub fn create_fresh_hive(
+    beehive_dir: &str,
+    repo_spec: &str,
+    description: &str,
+    private: bool,
+    comb_name: &str,
+    branch: &str,
+) -> Result<(HiveInfo, Comb), String> {
+    let (owner, repo_name, normalized_repo_spec) = parse_new_repo_spec(repo_spec)?;
+    let comb_name = comb_name.trim();
+    validate_comb_name(comb_name, &[])?;
+    let branch = validate_initial_branch(branch)?;
+    let description = description.trim();
+
+    let dir_name = format!("repo_{}", repo_name);
+    let hive_dir = Path::new(beehive_dir).join(&dir_name);
+    if hive_dir.exists() {
+        return Err(format!("A local hive for '{}' already exists", repo_name));
+    }
+
+    let dot_hive = hive_dir.join(".hive");
+    let comb_dir = hive_dir.join(comb_name);
+    fs::create_dir_all(&dot_hive).map_err(|e| format!("Failed to create .hive dir: {}", e))?;
+    fs::create_dir_all(&comb_dir).map_err(|e| format!("Failed to create comb dir: {}", e))?;
+
+    let cleanup_local = |error: String| -> String {
+        let _ = fs::remove_dir_all(&hive_dir);
+        error
+    };
+
+    init_fresh_comb_repo(&comb_dir, &repo_name, description, &branch, &owner)
+        .map_err(&cleanup_local)?;
+    create_remote_from_comb(&comb_dir, &normalized_repo_spec, description, private)
+        .map_err(&cleanup_local)?;
+    let repo_url = run_cmd_in_dir(
+        "git",
+        &["remote", "get-url", "origin"],
+        &comb_dir,
+        "Read remote",
+    )
+    .map_err(&cleanup_local)?;
+    run_cmd("git", &["ls-remote", "--heads", &repo_url]).map_err(|e| {
+        cleanup_local(format!(
+            "Created repository, but the configured remote is not accessible via git: {}",
+            e
+        ))
+    })?;
+
+    let mut info = hive_info_from_gh_repo(&normalized_repo_spec, &owner, &repo_name, repo_url)
+        .map_err(|e| cleanup_local(format!("Created repository, but failed to read it: {}", e)))?;
+    info.dir_name = dir_name.clone();
+
+    let comb = Comb {
+        id: uuid::Uuid::new_v4().to_string(),
+        name: comb_name.to_string(),
+        branch,
+        path: comb_dir.to_string_lossy().to_string(),
+        created_at: chrono_now(),
+        nest_id: None,
+        panes: vec![],
+        cloning: false,
+        operation: None,
+    };
+    let state = HiveState {
+        info: info.clone(),
+        nests: vec![],
+        combs: vec![comb.clone()],
+    };
+    save_hive_state(beehive_dir, &info.dir_name, &state).map_err(cleanup_local)?;
+
+    Ok((info, comb))
+}
+
+fn command_failure(action: &str, output: &std::process::Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let detail = if stderr.is_empty() { stdout } else { stderr };
+    if detail.is_empty() {
+        format!("{} failed", action)
+    } else {
+        format!(
+            "{} failed: {}",
+            action,
+            detail.lines().next().unwrap_or("unknown error")
+        )
+    }
+}
+
+fn run_cmd_in_dir(cmd: &str, args: &[&str], dir: &Path, action: &str) -> Result<String, String> {
+    let output = cmd_with_path(cmd)
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .map_err(|e| format!("{} failed: {}", action, e))?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(command_failure(action, &output))
+    }
+}
+
+fn gh_current_login() -> Result<String, String> {
+    run_cmd("gh", &["api", "user", "--jq", ".login"])
+        .map_err(|e| format!("Failed to determine GitHub user: {}", e))
+}
+
+fn validate_github_owner(owner: &str) -> Result<(), String> {
+    if owner.is_empty() {
+        return Err("Owner cannot be empty".to_string());
+    }
+    if !owner.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+        return Err("Owner can only contain letters, numbers, and hyphens".to_string());
+    }
+    Ok(())
+}
+
+fn validate_github_repo_name(repo_name: &str) -> Result<(), String> {
+    if repo_name.is_empty() {
+        return Err("Repository name cannot be empty".to_string());
+    }
+    if repo_name == "." || repo_name == ".." {
+        return Err("Repository name is reserved".to_string());
+    }
+    if repo_name.len() > 100 {
+        return Err("Repository name must be 100 characters or fewer".to_string());
+    }
+    if !repo_name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    {
+        return Err(
+            "Repository name can only contain letters, numbers, hyphens, underscores, and dots"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn parse_new_repo_spec(repo_spec: &str) -> Result<(String, String, String), String> {
+    let cleaned = repo_spec
+        .trim()
+        .trim_end_matches('/')
+        .trim_end_matches(".git");
+    if cleaned.is_empty() {
+        return Err("Repository name cannot be empty".to_string());
+    }
+
+    let (owner, repo_name) = if cleaned.starts_with("git@") || cleaned.contains("github.com/") {
+        parse_repo_url(cleaned)?
+    } else {
+        let parts: Vec<&str> = cleaned.split('/').collect();
+        match parts.as_slice() {
+            [repo] => (gh_current_login()?, (*repo).to_string()),
+            [owner, repo] => ((*owner).to_string(), (*repo).to_string()),
+            _ => return Err("Use a repository name or owner/repo for new repositories".to_string()),
+        }
+    };
+
+    validate_github_owner(&owner)?;
+    validate_github_repo_name(&repo_name)?;
+    Ok((
+        owner.clone(),
+        repo_name.clone(),
+        format!("{}/{}", owner, repo_name),
+    ))
+}
+
+fn validate_initial_branch(branch: &str) -> Result<String, String> {
+    let branch = branch.trim();
+    if branch.is_empty() {
+        return Err("Branch name cannot be empty".to_string());
+    }
+    if branch.starts_with('-')
+        || branch.contains("..")
+        || branch.ends_with(".lock")
+        || branch.chars().any(|c| c.is_whitespace())
+        || branch
+            .chars()
+            .any(|c| matches!(c, '~' | '^' | ':' | '?' | '*' | '[' | '\\'))
+    {
+        return Err("Branch name is not valid for git".to_string());
+    }
+    Ok(branch.to_string())
+}
+
+fn ensure_local_git_identity(dir: &Path, fallback_owner: &str) -> Result<(), String> {
+    let login = gh_current_login().unwrap_or_else(|_| fallback_owner.to_string());
+
+    let needs_name = run_cmd_in_dir("git", &["config", "user.name"], dir, "Read git user.name")
+        .map(|name| name.trim().is_empty())
+        .unwrap_or(true);
+    if needs_name {
+        run_cmd_in_dir(
+            "git",
+            &["config", "user.name", &login],
+            dir,
+            "Set git user.name",
+        )?;
+    }
+
+    let needs_email = run_cmd_in_dir("git", &["config", "user.email"], dir, "Read git user.email")
+        .map(|email| email.trim().is_empty())
+        .unwrap_or(true);
+    if needs_email {
+        let email = format!("{}@users.noreply.github.com", login);
+        run_cmd_in_dir(
+            "git",
+            &["config", "user.email", &email],
+            dir,
+            "Set git user.email",
+        )?;
+    }
+
+    Ok(())
+}
+
+fn init_fresh_comb_repo(
+    comb_dir: &Path,
+    repo_name: &str,
+    description: &str,
+    branch: &str,
+    fallback_owner: &str,
+) -> Result<(), String> {
+    run_cmd_in_dir("git", &["init"], comb_dir, "Initialize git repository")?;
+    run_cmd_in_dir(
+        "git",
+        &["checkout", "-b", branch],
+        comb_dir,
+        "Create branch",
+    )?;
+    ensure_local_git_identity(comb_dir, fallback_owner)?;
+
+    let mut readme = format!("# {}\n", repo_name);
+    if !description.is_empty() {
+        readme.push('\n');
+        readme.push_str(description);
+        readme.push('\n');
+    }
+    fs::write(comb_dir.join("README.md"), readme)
+        .map_err(|e| format!("Failed to write README.md: {}", e))?;
+    run_cmd_in_dir("git", &["add", "README.md"], comb_dir, "Stage README")?;
+    run_cmd_in_dir(
+        "git",
+        &["commit", "-m", "Initial commit"],
+        comb_dir,
+        "Create initial commit",
+    )?;
+    Ok(())
+}
+
+fn create_remote_from_comb(
+    comb_dir: &Path,
+    repo_spec: &str,
+    description: &str,
+    private: bool,
+) -> Result<(), String> {
+    let visibility = if private { "--private" } else { "--public" };
+    let mut cmd = cmd_with_path("gh");
+    cmd.env("GH_PROMPT_DISABLED", "1")
+        .current_dir(comb_dir)
+        .args([
+            "repo", "create", repo_spec, visibility, "--source", ".", "--remote", "origin",
+            "--push",
+        ]);
+    if !description.is_empty() {
+        cmd.args(["--description", description]);
+    }
+
+    let output = cmd
+        .output()
+        .map_err(|e| format!("Create GitHub repository failed: {}", e))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(command_failure("Create GitHub repository", &output))
+    }
+}
+
+fn hive_info_from_gh_repo(
+    repo_spec: &str,
+    fallback_owner: &str,
+    fallback_repo_name: &str,
+    repo_url: String,
+) -> Result<HiveInfo, String> {
+    let json_output = run_cmd(
+        "gh",
+        &[
+            "repo",
+            "view",
+            repo_spec,
+            "--json",
+            "name,owner,description,defaultBranchRef",
+        ],
+    )?;
+    let parsed: serde_json::Value =
+        serde_json::from_str(&json_output).map_err(|e| format!("Parse: {}", e))?;
+    let repo_name = parsed["name"]
+        .as_str()
+        .unwrap_or(fallback_repo_name)
+        .to_string();
+    let owner = parsed["owner"]["login"]
+        .as_str()
+        .unwrap_or(fallback_owner)
+        .to_string();
+    let description = parsed["description"].as_str().map(|s| s.to_string());
+    let default_branch = parsed["defaultBranchRef"]["name"]
+        .as_str()
+        .map(|s| s.to_string());
+
+    Ok(HiveInfo {
+        dir_name: format!("repo_{}", repo_name),
+        repo_url,
+        repo_name,
+        owner,
+        description,
+        default_branch,
+        custom_buttons: vec![],
+    })
+}
+
 pub fn get_combs(beehive_dir: &str, dir_name: &str) -> Result<Vec<Comb>, String> {
     Ok(load_hive_state_with_branches(beehive_dir, dir_name)?.combs)
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -197,9 +197,10 @@ fn run_app(
         // --- Phase 2: Background checks ---
         let clone_done = check_pending_clones(app);
         let delete_done = check_pending_deletes(app);
+        let attention_changed = app.drain_opencode_attention();
 
         // Force redraw when operations complete or are still in progress (spinner animation)
-        if clone_done || delete_done || app.has_pending_work() {
+        if clone_done || delete_done || attention_changed || app.has_pending_work() {
             dirty = true;
         }
 
@@ -745,6 +746,15 @@ fn handle_key(
                 KeyCode::Char('f') => app.start_comb_finder(),
                 KeyCode::Char('m') => app.start_move_comb(),
                 KeyCode::Char('c') => app.start_copy_comb(),
+                KeyCode::Char('o') => {
+                    if let Some((id, path)) = app.selected_comb_target() {
+                        if Path::new(&path).exists() {
+                            app.open_opencode_terminal(&id, &path);
+                        } else {
+                            app.status_message = Some("Dir not found".to_string());
+                        }
+                    }
+                }
                 KeyCode::Char('a') => app.start_add_hive(),
                 KeyCode::Char('A') => app.start_create_fresh_hive(),
                 KeyCode::Char('d') => app.start_delete(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -759,8 +759,15 @@ fn handle_key(
                 KeyCode::Char('A') => app.start_create_fresh_hive(),
                 KeyCode::Char('d') => app.start_delete(),
                 KeyCode::Char('R') => {
-                    app.refresh();
-                    app.status_message = Some("Refreshed".to_string());
+                    if let Some((id, path)) = app.selected_comb_target() {
+                        if Path::new(&path).exists() {
+                            app.restart_comb_terminal(&id, &path);
+                        } else {
+                            app.status_message = Some("Dir not found".to_string());
+                        }
+                    } else {
+                        app.status_message = Some("Select a comb to restart".to_string());
+                    }
                 }
                 KeyCode::Char('s') => app.open_settings(),
                 KeyCode::Char('?') => app.open_help(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -746,6 +746,7 @@ fn handle_key(
                 KeyCode::Char('m') => app.start_move_comb(),
                 KeyCode::Char('c') => app.start_copy_comb(),
                 KeyCode::Char('a') => app.start_add_hive(),
+                KeyCode::Char('A') => app.start_create_fresh_hive(),
                 KeyCode::Char('d') => app.start_delete(),
                 KeyCode::Char('R') => {
                     app.refresh();
@@ -1863,6 +1864,23 @@ fn handle_input_submit(
 
                 match add_hive(&app.beehive_dir, &value) {
                     Ok(name) => app.status_message = Some(format!("Added '{}'", name)),
+                    Err(e) => app.status_message = Some(format!("Failed: {}", e)),
+                }
+                app.refresh();
+            }
+            InputAction::CreateFreshHiveRepo => {
+                app.status_message = Some("Creating repo...".to_string());
+                terminal.draw(|frame| {
+                    ui::render(frame, app);
+                })?;
+
+                match create_fresh_hive(&app.beehive_dir, &value, "", true, "main", "main") {
+                    Ok((hive, comb)) => {
+                        app.status_message = Some(format!(
+                            "Created '{}' with comb '{}'",
+                            hive.repo_name, comb.name
+                        ));
+                    }
                     Err(e) => app.status_message = Some(format!("Failed: {}", e)),
                 }
                 app.refresh();

--- a/cli/src/terminal.rs
+++ b/cli/src/terminal.rs
@@ -142,6 +142,10 @@ fn startup_wrapper_script() -> &'static str {
     "eval \"$BEEHIVE_STARTUP_COMMAND\"\nexec \"$SHELL\" -l"
 }
 
+fn opencode_wrapper_script(port: u16) -> String {
+    format!("opencode --hostname 127.0.0.1 --port {}\nexec \"$SHELL\" -l", port)
+}
+
 pub struct EmbeddedTerminal {
     /// vt100 parser — owned exclusively by the main thread (no locks needed).
     /// Background reader sends raw bytes via `output_rx` channel instead.
@@ -172,6 +176,7 @@ impl EmbeddedTerminal {
         cols: u16,
         outer_keyboard_enhanced: bool,
         startup_command: Option<&str>,
+        opencode_port: Option<u16>,
     ) -> Result<Self, String> {
         let pty_system = native_pty_system();
 
@@ -185,15 +190,24 @@ impl EmbeddedTerminal {
             .map_err(|e| format!("Failed to open PTY: {}", e))?;
 
         let shell = resolve_login_shell();
-        let mut cmd = CommandBuilder::new(&shell);
-        if let Some(startup_command) = normalize_startup_command(startup_command) {
+        let mut cmd = if let Some(port) = opencode_port {
+            let mut cmd = CommandBuilder::new(&shell);
             cmd.arg("-lc");
-            cmd.arg(startup_wrapper_script());
+            cmd.arg(opencode_wrapper_script(port));
             cmd.env("SHELL", &shell);
-            cmd.env("BEEHIVE_STARTUP_COMMAND", startup_command);
+            cmd
         } else {
-            cmd.arg("-l");
-        }
+            let mut cmd = CommandBuilder::new(&shell);
+            if let Some(startup_command) = normalize_startup_command(startup_command) {
+                cmd.arg("-lc");
+                cmd.arg(startup_wrapper_script());
+                cmd.env("SHELL", &shell);
+                cmd.env("BEEHIVE_STARTUP_COMMAND", startup_command);
+            } else {
+                cmd.arg("-l");
+            }
+            cmd
+        };
         cmd.cwd(cwd);
         cmd.env("TERM", "xterm-256color");
         cmd.env("PATH", full_path());

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -8,7 +8,7 @@ use ratatui::{
 };
 
 use crate::{
-    app::{filter_comb_finder_targets, App, AppMode, Focus, NavItem},
+    app::{filter_comb_finder_targets, App, AppMode, Focus, NavItem, OpenCodeAttentionKind},
     fuzzy::fuzzy_filter_strings,
 };
 
@@ -371,23 +371,51 @@ fn render_sidebar(frame: &mut Frame, app: &App, area: Rect) {
 
                     let has_terminal = app.terminals.contains_key(&comb.id);
 
-                    let (marker, marker_color) = if is_active {
-                        ("▶ ", GREEN)
-                    } else if has_terminal {
-                        ("● ", BLUE)
-                    } else {
-                        ("  ", MANTLE)
+                    let attention = app.opencode_attention.get(&comb.id);
+                    let (attention_text, attention_color) = match attention {
+                        Some(OpenCodeAttentionKind::Input) => (Some(" needs input"), YELLOW),
+                        Some(OpenCodeAttentionKind::Idle) => (Some(" ready"), GREEN),
+                        Some(OpenCodeAttentionKind::Error) => (Some(" error"), RED),
+                        _ => (None, SURFACE1),
                     };
-                    let name_color = if is_active { GREEN } else { TEXT };
 
-                    ListItem::new(Line::from(vec![
+                    let (marker, marker_color) =
+                        if matches!(attention, Some(OpenCodeAttentionKind::Input)) {
+                            ("! ", YELLOW)
+                        } else if matches!(attention, Some(OpenCodeAttentionKind::Error)) {
+                            ("! ", RED)
+                        } else if matches!(attention, Some(OpenCodeAttentionKind::Idle)) {
+                            ("● ", GREEN)
+                        } else if is_active {
+                            ("▶ ", GREEN)
+                        } else if has_terminal {
+                            ("● ", BLUE)
+                        } else {
+                            ("  ", MANTLE)
+                        };
+                    let name_color = if matches!(attention, Some(OpenCodeAttentionKind::Input)) {
+                        YELLOW
+                    } else if matches!(attention, Some(OpenCodeAttentionKind::Error)) {
+                        RED
+                    } else if is_active {
+                        GREEN
+                    } else {
+                        TEXT
+                    };
+
+                    let mut spans = vec![
                         Span::styled(
                             format!("{}{}", indent, marker),
                             Style::default().fg(marker_color),
                         ),
                         Span::styled(comb.name.clone(), Style::default().fg(name_color)),
                         Span::styled(format!(" {}", comb.branch), Style::default().fg(SURFACE1)),
-                    ]))
+                    ];
+                    if let Some(text) = attention_text {
+                        spans.push(Span::styled(text, Style::default().fg(attention_color)));
+                    }
+
+                    ListItem::new(Line::from(spans))
                 }
             }
         })
@@ -645,6 +673,12 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                         Span::styled(" copy ", Style::default().fg(OVERLAY0)),
                         Span::styled("│", Style::default().fg(SURFACE1)),
                         Span::styled(
+                            " o",
+                            Style::default().fg(LAVENDER).add_modifier(Modifier::BOLD),
+                        ),
+                        Span::styled(" opencode ", Style::default().fg(OVERLAY0)),
+                        Span::styled("│", Style::default().fg(SURFACE1)),
+                        Span::styled(
                             " r",
                             Style::default().fg(LAVENDER).add_modifier(Modifier::BOLD),
                         ),
@@ -794,6 +828,10 @@ fn render_help(frame: &mut Frame) {
         Line::from(vec![
             Span::styled("  c        ", key_style),
             Span::styled("Copy comb (duplicate workspace)", desc_style),
+        ]),
+        Line::from(vec![
+            Span::styled("  o        ", key_style),
+            Span::styled("Open OpenCode and watch for attention", desc_style),
         ]),
         Line::from(vec![
             Span::styled("  r        ", key_style),

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -181,6 +181,10 @@ fn render_sidebar(frame: &mut Frame, app: &App, area: Rect) {
                 "Press 'a' to add a repo",
                 Style::default().fg(OVERLAY0),
             )),
+            Line::from(Span::styled(
+                "Press 'A' to create one",
+                Style::default().fg(OVERLAY0),
+            )),
         ])
         .alignment(Alignment::Center)
         .style(Style::default().bg(MANTLE));
@@ -668,6 +672,12 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                     Span::styled(" add ", Style::default().fg(OVERLAY0)),
                     Span::styled("│", Style::default().fg(SURFACE1)),
                     Span::styled(
+                        " A",
+                        Style::default().fg(LAVENDER).add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(" create ", Style::default().fg(OVERLAY0)),
+                    Span::styled("│", Style::default().fg(SURFACE1)),
+                    Span::styled(
                         " d",
                         Style::default().fg(LAVENDER).add_modifier(Modifier::BOLD),
                     ),
@@ -796,6 +806,10 @@ fn render_help(frame: &mut Frame) {
         Line::from(vec![
             Span::styled("  a        ", key_style),
             Span::styled("Add hive (GitHub repo)", desc_style),
+        ]),
+        Line::from(vec![
+            Span::styled("  A        ", key_style),
+            Span::styled("Create repo + first comb", desc_style),
         ]),
         Line::from(vec![
             Span::styled("  d        ", key_style),

--- a/cli/src/ui.rs
+++ b/cli/src/ui.rs
@@ -685,6 +685,12 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                         Span::styled(" rename ", Style::default().fg(OVERLAY0)),
                         Span::styled("│", Style::default().fg(SURFACE1)),
                         Span::styled(
+                            " R",
+                            Style::default().fg(LAVENDER).add_modifier(Modifier::BOLD),
+                        ),
+                        Span::styled(" restart ", Style::default().fg(OVERLAY0)),
+                        Span::styled("│", Style::default().fg(SURFACE1)),
+                        Span::styled(
                             " f",
                             Style::default().fg(LAVENDER).add_modifier(Modifier::BOLD),
                         ),
@@ -838,6 +844,10 @@ fn render_help(frame: &mut Frame) {
             Span::styled("Rename selected comb or nest", desc_style),
         ]),
         Line::from(vec![
+            Span::styled("  R        ", key_style),
+            Span::styled("Restart selected comb terminal", desc_style),
+        ]),
+        Line::from(vec![
             Span::styled("  f        ", key_style),
             Span::styled("Find and jump to a comb", desc_style),
         ]),
@@ -860,10 +870,6 @@ fn render_help(frame: &mut Frame) {
         Line::from(vec![
             Span::styled("  </>/H/L  ", key_style),
             Span::styled("Resize sidebar", desc_style),
-        ]),
-        Line::from(vec![
-            Span::styled("  R        ", key_style),
-            Span::styled("Refresh sidebar", desc_style),
         ]),
         Line::from(vec![
             Span::styled("  s        ", key_style),

--- a/src-tauri/src/hive.rs
+++ b/src-tauri/src/hive.rs
@@ -86,6 +86,13 @@ pub struct HiveOperationResult {
     pub error: Option<String>,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FreshHiveResult {
+    pub hive: HiveInfo,
+    pub comb: Comb,
+}
+
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HiveState {
@@ -469,6 +476,88 @@ pub async fn create_hive(beehive_dir: String, repo_url: String) -> Result<HiveIn
     }
 
     Ok(info)
+}
+
+#[tauri::command]
+pub async fn create_fresh_hive(
+    beehive_dir: String,
+    repo_spec: String,
+    description: String,
+    private: bool,
+    comb_name: String,
+    branch: String,
+) -> Result<FreshHiveResult, String> {
+    let (owner, repo_name, normalized_repo_spec) = parse_new_repo_spec(&repo_spec)?;
+    let comb_name = comb_name.trim().to_string();
+    validate_comb_name(&comb_name, &[])?;
+    let branch = validate_initial_branch(&branch)?;
+    let description = description.trim().to_string();
+
+    let dir_name = format!("repo_{}", repo_name);
+    let hive_dir = Path::new(&beehive_dir).join(&dir_name);
+    if hive_dir.exists() {
+        return Err(format!(
+            "A local hive directory for '{}' already exists at {}",
+            repo_name,
+            hive_dir.to_string_lossy()
+        ));
+    }
+
+    let dot_hive = hive_dir.join(".hive");
+    let comb_dir = hive_dir.join(&comb_name);
+    fs::create_dir_all(&dot_hive).map_err(|e| format!("Failed to create .hive dir: {}", e))?;
+    fs::create_dir_all(&comb_dir).map_err(|e| format!("Failed to create comb dir: {}", e))?;
+
+    let cleanup_local = |error: String| -> String {
+        let _ = fs::remove_dir_all(&hive_dir);
+        error
+    };
+
+    init_fresh_comb_repo(&comb_dir, &repo_name, &description, &branch, &owner)
+        .map_err(&cleanup_local)?;
+
+    create_remote_from_comb(&comb_dir, &normalized_repo_spec, &description, private)
+        .map_err(&cleanup_local)?;
+
+    let repo_url = run_cmd_in_dir(
+        "git",
+        &["remote", "get-url", "origin"],
+        &comb_dir,
+        "Read remote",
+    )
+    .map_err(&cleanup_local)?;
+
+    run_cmd("git", &["ls-remote", "--heads", &repo_url]).map_err(|e| {
+        cleanup_local(format!(
+            "Created repository, but the configured remote is not accessible via git: {}",
+            e
+        ))
+    })?;
+
+    let mut info = hive_info_from_gh_repo(&normalized_repo_spec, &owner, &repo_name, repo_url)
+        .map_err(|e| cleanup_local(format!("Created repository, but failed to read it: {}", e)))?;
+    info.dir_name = dir_name.clone();
+
+    let comb = Comb {
+        id: uuid::Uuid::new_v4().to_string(),
+        name: comb_name,
+        branch,
+        path: comb_dir.to_string_lossy().to_string(),
+        created_at: chrono_now(),
+        nest_id: None,
+        panes: vec![],
+        cloning: false,
+        operation: None,
+    };
+
+    let state = HiveState {
+        info: info.clone(),
+        nests: vec![],
+        combs: vec![comb.clone()],
+    };
+    save_hive_state(&beehive_dir, &info.dir_name, &state).map_err(cleanup_local)?;
+
+    Ok(FreshHiveResult { hive: info, comb })
 }
 
 #[tauri::command]
@@ -1579,6 +1668,256 @@ pub async fn cli_status() -> Result<CliStatusResult, String> {
 }
 
 // --- helpers ---
+
+fn command_failure(action: &str, output: &std::process::Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let detail = if stderr.is_empty() { stdout } else { stderr };
+    if detail.is_empty() {
+        format!("{} failed", action)
+    } else {
+        format!(
+            "{} failed: {}",
+            action,
+            detail.lines().next().unwrap_or("unknown error")
+        )
+    }
+}
+
+fn run_cmd_in_dir(cmd: &str, args: &[&str], dir: &Path, action: &str) -> Result<String, String> {
+    let output = cmd_with_path(cmd)
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .map_err(|e| format!("{} failed: {}", action, e))?;
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(command_failure(action, &output))
+    }
+}
+
+fn gh_current_login() -> Result<String, String> {
+    run_cmd("gh", &["api", "user", "--jq", ".login"])
+        .map_err(|e| format!("Failed to determine GitHub user: {}", e))
+}
+
+fn validate_github_owner(owner: &str) -> Result<(), String> {
+    if owner.is_empty() {
+        return Err("Owner cannot be empty".to_string());
+    }
+    if !owner.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+        return Err("Owner can only contain letters, numbers, and hyphens".to_string());
+    }
+    Ok(())
+}
+
+fn validate_github_repo_name(repo_name: &str) -> Result<(), String> {
+    if repo_name.is_empty() {
+        return Err("Repository name cannot be empty".to_string());
+    }
+    if repo_name == "." || repo_name == ".." {
+        return Err("Repository name is reserved".to_string());
+    }
+    if repo_name.len() > 100 {
+        return Err("Repository name must be 100 characters or fewer".to_string());
+    }
+    if !repo_name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    {
+        return Err(
+            "Repository name can only contain letters, numbers, hyphens, underscores, and dots"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn parse_new_repo_spec(repo_spec: &str) -> Result<(String, String, String), String> {
+    let cleaned = repo_spec
+        .trim()
+        .trim_end_matches('/')
+        .trim_end_matches(".git");
+    if cleaned.is_empty() {
+        return Err("Repository name cannot be empty".to_string());
+    }
+
+    let (owner, repo_name) = if cleaned.starts_with("git@") || cleaned.contains("github.com/") {
+        parse_repo_url(cleaned)?
+    } else {
+        let parts: Vec<&str> = cleaned.split('/').collect();
+        match parts.as_slice() {
+            [repo] => (gh_current_login()?, (*repo).to_string()),
+            [owner, repo] => ((*owner).to_string(), (*repo).to_string()),
+            _ => return Err("Use a repository name or owner/repo for new repositories".to_string()),
+        }
+    };
+
+    validate_github_owner(&owner)?;
+    validate_github_repo_name(&repo_name)?;
+
+    Ok((
+        owner.clone(),
+        repo_name.clone(),
+        format!("{}/{}", owner, repo_name),
+    ))
+}
+
+fn validate_initial_branch(branch: &str) -> Result<String, String> {
+    let branch = branch.trim();
+    if branch.is_empty() {
+        return Err("Branch name cannot be empty".to_string());
+    }
+    if branch.starts_with('-')
+        || branch.contains("..")
+        || branch.ends_with(".lock")
+        || branch.chars().any(|c| c.is_whitespace())
+        || branch
+            .chars()
+            .any(|c| matches!(c, '~' | '^' | ':' | '?' | '*' | '[' | '\\'))
+    {
+        return Err("Branch name is not valid for git".to_string());
+    }
+    Ok(branch.to_string())
+}
+
+fn ensure_local_git_identity(dir: &Path, fallback_owner: &str) -> Result<(), String> {
+    let login = gh_current_login().unwrap_or_else(|_| fallback_owner.to_string());
+
+    let needs_name = run_cmd_in_dir("git", &["config", "user.name"], dir, "Read git user.name")
+        .map(|name| name.trim().is_empty())
+        .unwrap_or(true);
+    if needs_name {
+        run_cmd_in_dir(
+            "git",
+            &["config", "user.name", &login],
+            dir,
+            "Set git user.name",
+        )?;
+    }
+
+    let needs_email = run_cmd_in_dir("git", &["config", "user.email"], dir, "Read git user.email")
+        .map(|email| email.trim().is_empty())
+        .unwrap_or(true);
+    if needs_email {
+        let email = format!("{}@users.noreply.github.com", login);
+        run_cmd_in_dir(
+            "git",
+            &["config", "user.email", &email],
+            dir,
+            "Set git user.email",
+        )?;
+    }
+
+    Ok(())
+}
+
+fn init_fresh_comb_repo(
+    comb_dir: &Path,
+    repo_name: &str,
+    description: &str,
+    branch: &str,
+    fallback_owner: &str,
+) -> Result<(), String> {
+    run_cmd_in_dir("git", &["init"], comb_dir, "Initialize git repository")?;
+    run_cmd_in_dir(
+        "git",
+        &["checkout", "-b", branch],
+        comb_dir,
+        "Create branch",
+    )?;
+    ensure_local_git_identity(comb_dir, fallback_owner)?;
+
+    let mut readme = format!("# {}\n", repo_name);
+    if !description.is_empty() {
+        readme.push('\n');
+        readme.push_str(description);
+        readme.push('\n');
+    }
+    fs::write(comb_dir.join("README.md"), readme)
+        .map_err(|e| format!("Failed to write README.md: {}", e))?;
+
+    run_cmd_in_dir("git", &["add", "README.md"], comb_dir, "Stage README")?;
+    run_cmd_in_dir(
+        "git",
+        &["commit", "-m", "Initial commit"],
+        comb_dir,
+        "Create initial commit",
+    )?;
+    Ok(())
+}
+
+fn create_remote_from_comb(
+    comb_dir: &Path,
+    repo_spec: &str,
+    description: &str,
+    private: bool,
+) -> Result<(), String> {
+    let visibility = if private { "--private" } else { "--public" };
+    let mut cmd = cmd_with_path("gh");
+    cmd.env("GH_PROMPT_DISABLED", "1")
+        .current_dir(comb_dir)
+        .args([
+            "repo", "create", repo_spec, visibility, "--source", ".", "--remote", "origin",
+            "--push",
+        ]);
+    if !description.is_empty() {
+        cmd.args(["--description", description]);
+    }
+
+    let output = cmd
+        .output()
+        .map_err(|e| format!("Create GitHub repository failed: {}", e))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(command_failure("Create GitHub repository", &output))
+    }
+}
+
+fn hive_info_from_gh_repo(
+    repo_spec: &str,
+    fallback_owner: &str,
+    fallback_repo_name: &str,
+    repo_url: String,
+) -> Result<HiveInfo, String> {
+    let json_output = run_cmd(
+        "gh",
+        &[
+            "repo",
+            "view",
+            repo_spec,
+            "--json",
+            "name,owner,description,defaultBranchRef",
+        ],
+    )?;
+
+    let parsed: serde_json::Value = serde_json::from_str(&json_output)
+        .map_err(|e| format!("Failed to parse gh output: {}", e))?;
+    let repo_name = parsed["name"]
+        .as_str()
+        .unwrap_or(fallback_repo_name)
+        .to_string();
+    let owner = parsed["owner"]["login"]
+        .as_str()
+        .unwrap_or(fallback_owner)
+        .to_string();
+    let description = parsed["description"].as_str().map(|s| s.to_string());
+    let default_branch = parsed["defaultBranchRef"]["name"]
+        .as_str()
+        .map(|s| s.to_string());
+
+    Ok(HiveInfo {
+        dir_name: format!("repo_{}", repo_name),
+        repo_url,
+        repo_name,
+        owner,
+        description,
+        default_branch,
+        custom_buttons: vec![],
+    })
+}
 
 fn parse_repo_url(url: &str) -> Result<(String, String), String> {
     // Handle: git@github.com:owner/repo.git

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,6 +34,7 @@ pub fn run() {
             hive::load_beehive,
             hive::verify_repo,
             hive::create_hive,
+            hive::create_fresh_hive,
             hive::list_hives,
             hive::delete_hive,
             hive::delete_hive_start,

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -1,10 +1,17 @@
 use std::collections::{HashMap, HashSet};
+use std::io::{BufRead, BufReader};
 use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
 use std::sync::Arc;
+use std::time::Duration;
 
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
+use serde::Serialize;
+use serde_json::Value;
 use tauri::{AppHandle, Emitter, State};
 use tokio::sync::Mutex;
+
+const OPENCODE_SENTINEL: &str = "__beehive_opencode__";
 
 pub struct PtySession {
     master: Arc<std::sync::Mutex<Box<dyn MasterPty + Send>>>,
@@ -49,6 +56,156 @@ fn startup_wrapper_script() -> &'static str {
     "eval \"$BEEHIVE_STARTUP_COMMAND\"\nexec \"$SHELL\" -l"
 }
 
+fn opencode_wrapper_script(port: u16) -> String {
+    format!("opencode --hostname 127.0.0.1 --port {}\nexec \"$SHELL\" -l", port)
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenCodeAttentionEvent {
+    pub attention_key: String,
+    pub status: String,
+    pub event_type: String,
+}
+
+fn reserve_local_port() -> Result<u16, String> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .map_err(|e| format!("Failed to reserve OpenCode port: {}", e))?;
+    let port = listener
+        .local_addr()
+        .map_err(|e| format!("Failed to read OpenCode port: {}", e))?
+        .port();
+    drop(listener);
+    Ok(port)
+}
+
+fn json_event_type(data: &str) -> Option<String> {
+    let value: Value = serde_json::from_str(data).ok()?;
+    value
+        .get("type")
+        .or_else(|| value.get("name"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+fn classify_opencode_event(event_type: &str, data: &str) -> Option<&'static str> {
+    match event_type {
+        "permission.asked" | "question.asked" => Some("input"),
+        "permission.replied" | "question.replied" | "question.rejected" => Some("clear"),
+        "session.error" => Some("error"),
+        "session.idle" => Some("idle"),
+        "session.status" => {
+            let value: Value = serde_json::from_str(data).ok()?;
+            let status_type = value
+                .pointer("/properties/status/type")
+                .or_else(|| value.pointer("/status/type"))
+                .and_then(Value::as_str);
+            match status_type {
+                Some("idle") => Some("idle"),
+                Some("busy") | Some("retry") => Some("clear"),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn emit_opencode_attention(app: &AppHandle, attention_key: &str, status: &str, event_type: &str) {
+    let _ = app.emit(
+        "opencode-attention",
+        OpenCodeAttentionEvent {
+            attention_key: attention_key.to_string(),
+            status: status.to_string(),
+            event_type: event_type.to_string(),
+        },
+    );
+}
+
+fn start_opencode_event_listener(app: AppHandle, attention_key: String, port: u16) {
+    std::thread::spawn(move || {
+        let mut stream = None;
+        for _ in 0..300 {
+            match TcpStream::connect(("127.0.0.1", port)) {
+                Ok(s) => {
+                    stream = Some(s);
+                    break;
+                }
+                Err(_) => std::thread::sleep(Duration::from_millis(100)),
+            }
+        }
+
+        let Some(mut stream) = stream else {
+            emit_opencode_attention(
+                &app,
+                &attention_key,
+                "error",
+                "beehive.opencode.connect_failed",
+            );
+            return;
+        };
+
+        let request = format!(
+            "GET /event HTTP/1.1\r\nHost: 127.0.0.1:{}\r\nAccept: text/event-stream\r\nConnection: close\r\n\r\n",
+            port
+        );
+        if stream.write_all(request.as_bytes()).is_err() {
+            emit_opencode_attention(
+                &app,
+                &attention_key,
+                "error",
+                "beehive.opencode.subscribe_failed",
+            );
+            return;
+        }
+
+        let mut reader = BufReader::new(stream);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => return,
+                Ok(_) if line == "\r\n" || line == "\n" => break,
+                Ok(_) => continue,
+                Err(_) => return,
+            }
+        }
+
+        let mut event_name: Option<String> = None;
+        let mut data = String::new();
+        loop {
+            line.clear();
+            let read = match reader.read_line(&mut line) {
+                Ok(read) => read,
+                Err(_) => return,
+            };
+            if read == 0 {
+                return;
+            }
+
+            let trimmed = line.trim_end_matches(['\r', '\n']);
+            if trimmed.is_empty() {
+                if !data.is_empty() {
+                    let event_type = event_name.clone().or_else(|| json_event_type(&data));
+                    if let Some(event_type) = event_type {
+                        if let Some(status) = classify_opencode_event(&event_type, &data) {
+                            emit_opencode_attention(&app, &attention_key, status, &event_type);
+                        }
+                    }
+                }
+                event_name = None;
+                data.clear();
+            } else if let Some(value) = trimmed.strip_prefix("event:") {
+                event_name = Some(value.trim().to_string());
+            } else if let Some(value) = trimmed.strip_prefix("data:") {
+                if !data.is_empty() {
+                    data.push('\n');
+                }
+                data.push_str(value.trim_start());
+            }
+        }
+    });
+}
+
 #[tauri::command]
 pub async fn create_pty(
     id: String,
@@ -57,12 +214,18 @@ pub async fn create_pty(
     args: Option<Vec<String>>,
     rows: u16,
     cols: u16,
+    attention_key: Option<String>,
     app: AppHandle,
     state: State<'_, PtyState>,
 ) -> Result<(), String> {
     let pty_system = native_pty_system();
+    let opencode_port = if matches!(cmd.as_deref(), Some(OPENCODE_SENTINEL)) {
+        Some(reserve_local_port()?)
+    } else {
+        None
+    };
 
-    let startup_command = if cmd.is_none() {
+    let startup_command = if cmd.is_none() && opencode_port.is_none() {
         let config = crate::hive::load_app_config().await?;
         normalize_startup_command(config.comb_startup_command.as_deref()).map(str::to_string)
     } else {
@@ -89,8 +252,16 @@ pub async fn create_pty(
         })
         .map_err(|e| format!("Failed to open PTY: {}", e))?;
 
-    let mut command = match &cmd {
-        Some(c) => {
+    let mut command = match (&cmd, opencode_port) {
+        (_, Some(port)) => {
+            let shell = resolve_login_shell();
+            let mut cb = CommandBuilder::new(&shell);
+            cb.arg("-lc");
+            cb.arg(opencode_wrapper_script(port));
+            cb.env("SHELL", &shell);
+            cb
+        }
+        (Some(c), None) => {
             let mut cb = CommandBuilder::new(c);
             if let Some(ref a) = args {
                 for arg in a {
@@ -99,7 +270,7 @@ pub async fn create_pty(
             }
             cb
         }
-        None => {
+        (None, None) => {
             let shell = resolve_login_shell();
             let mut cb = CommandBuilder::new(&shell);
             if let Some(startup_command) = startup_command.as_deref() {
@@ -131,6 +302,10 @@ pub async fn create_pty(
         .slave
         .spawn_command(command)
         .map_err(|e| format!("Failed to spawn: {}", e))?;
+
+    if let (Some(port), Some(key)) = (opencode_port, attention_key) {
+        start_opencode_event_listener(app.clone(), key, port);
+    }
 
     let writer = pair
         .master

--- a/src/App.css
+++ b/src/App.css
@@ -82,6 +82,22 @@ input, select {
   transition: border-color 0.15s;
 }
 
+input[type="checkbox"] {
+  width: auto;
+  padding: 0;
+  accent-color: var(--accent);
+}
+
+.checkbox-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 4px 0 16px;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 500;
+}
+
 input:focus, select:focus {
   border-color: var(--accent);
 }

--- a/src/App.css
+++ b/src/App.css
@@ -850,6 +850,21 @@ select option {
   background: var(--bg-surface);
 }
 
+.sidebar-comb-item.attention-input {
+  border-left-color: var(--warning);
+  background: rgba(249, 226, 175, 0.08);
+}
+
+.sidebar-comb-item.attention-idle {
+  border-left-color: var(--success);
+  background: rgba(166, 227, 161, 0.06);
+}
+
+.sidebar-comb-item.attention-error {
+  border-left-color: var(--danger);
+  background: rgba(243, 139, 168, 0.08);
+}
+
 .sidebar-comb-info {
   display: flex;
   flex-direction: column;
@@ -904,6 +919,26 @@ select option {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.sidebar-comb-attention {
+  margin-left: 6px;
+  font-family: inherit;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.sidebar-comb-item.attention-input .sidebar-comb-attention {
+  color: var(--warning);
+}
+
+.sidebar-comb-item.attention-idle .sidebar-comb-attention {
+  color: var(--success);
+}
+
+.sidebar-comb-item.attention-error .sidebar-comb-attention {
+  color: var(--danger);
 }
 
 .sidebar-comb-actions {

--- a/src/components/HiveListScreen.tsx
+++ b/src/components/HiveListScreen.tsx
@@ -1,6 +1,58 @@
 import { useEffect, useState, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import type { HiveInfo } from "../types";
+import type { Comb, HiveInfo } from "../types";
+
+type AddMode = "existing" | "new";
+
+interface FreshHiveResult {
+  hive: HiveInfo;
+  comb: Comb;
+}
+
+function validateFreshRepoSpec(value: string): string {
+  const cleaned = value.trim().replace(/\.git$/, "").replace(/\/$/, "");
+  if (!cleaned) return "Repository name is required";
+  if (cleaned.startsWith("git@") || cleaned.includes("github.com/")) return "";
+
+  const parts = cleaned.split("/");
+  if (parts.length > 2 || parts.some((part) => part.length === 0)) {
+    return "Use repo-name or owner/repo";
+  }
+  if (parts.length === 2 && !/^[a-zA-Z0-9-]+$/.test(parts[0])) {
+    return "Owner can only contain letters, numbers, and hyphens";
+  }
+
+  const repoName = parts[parts.length - 1];
+  if (!/^[a-zA-Z0-9._-]+$/.test(repoName)) {
+    return "Repo name can only contain letters, numbers, dots, hyphens, and underscores";
+  }
+  if (repoName === "." || repoName === "..") return "Repository name is reserved";
+  return "";
+}
+
+function validateCombName(name: string): string {
+  if (!name) return "Comb name is required";
+  if (name.length > 40) return "Comb name must be 40 characters or fewer";
+  if (name.startsWith(".") || name.startsWith("-")) return "Comb name cannot start with '.' or '-'";
+  if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+    return "Comb name can only contain letters, numbers, hyphens, and underscores";
+  }
+  return "";
+}
+
+function validateBranchName(name: string): string {
+  if (!name) return "Branch name is required";
+  if (
+    name.startsWith("-") ||
+    name.includes("..") ||
+    name.endsWith(".lock") ||
+    /\s/.test(name) ||
+    /[~^:?*[\\]/.test(name)
+  ) {
+    return "Branch name is not valid for git";
+  }
+  return "";
+}
 
 interface Props {
   beehiveDir: string;
@@ -16,7 +68,13 @@ interface Props {
 export function HiveListScreen({ beehiveDir, onSelectHive, onSettings, onHelp, onBack, backLabel, hivesDeleting, onDeleteHive }: Props) {
   const [hives, setHives] = useState<HiveInfo[]>([]);
   const [showAdd, setShowAdd] = useState(false);
+  const [addMode, setAddMode] = useState<AddMode>("existing");
   const [repoUrl, setRepoUrl] = useState("");
+  const [newRepoSpec, setNewRepoSpec] = useState("");
+  const [newRepoDescription, setNewRepoDescription] = useState("");
+  const [newRepoPrivate, setNewRepoPrivate] = useState(true);
+  const [newCombName, setNewCombName] = useState("main");
+  const [newBranch, setNewBranch] = useState("main");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
@@ -36,7 +94,7 @@ export function HiveListScreen({ beehiveDir, onSelectHive, onSettings, onHelp, o
     }
   }
 
-  async function handleAdd() {
+  async function handleAddExisting() {
     const trimmed = repoUrl.trim();
     if (!trimmed) {
       setError("Please enter a repository URL");
@@ -60,6 +118,52 @@ export function HiveListScreen({ beehiveDir, onSelectHive, onSettings, onHelp, o
       setError(`${e}`);
     }
     setLoading(false);
+  }
+
+  async function handleCreateFresh() {
+    const repoSpec = newRepoSpec.trim();
+    const combName = newCombName.trim();
+    const branch = newBranch.trim();
+    const validation =
+      validateFreshRepoSpec(repoSpec) ||
+      validateCombName(combName) ||
+      validateBranchName(branch);
+    if (validation) {
+      setError(validation);
+      return;
+    }
+
+    setLoading(true);
+    setError("");
+    try {
+      const result = await invoke<FreshHiveResult>("create_fresh_hive", {
+        beehiveDir,
+        repoSpec,
+        description: newRepoDescription.trim(),
+        private: newRepoPrivate,
+        combName,
+        branch,
+      });
+      setNewRepoSpec("");
+      setNewRepoDescription("");
+      setNewRepoPrivate(true);
+      setNewCombName("main");
+      setNewBranch("main");
+      setShowAdd(false);
+      await loadHives();
+      onSelectHive(result.hive);
+    } catch (e) {
+      setError(`${e}`);
+    }
+    setLoading(false);
+  }
+
+  function handleSubmitAdd() {
+    if (addMode === "existing") {
+      void handleAddExisting();
+    } else {
+      void handleCreateFresh();
+    }
   }
 
   const executeDelete = useCallback(async (dirName: string) => {
@@ -106,37 +210,126 @@ export function HiveListScreen({ beehiveDir, onSelectHive, onSettings, onHelp, o
 
         {showAdd && (
           <div className="add-form" style={{ marginBottom: 20 }}>
-            <div className="form-group">
-              <label>Repository URL</label>
-              <input
-                type="text"
-                value={repoUrl}
-                onChange={(e) => { setRepoUrl(e.target.value); setError(""); }}
-                placeholder="owner/repo or git@github.com:owner/repo.git"
-                onKeyDown={(e) => e.key === "Enter" && !loading && handleAdd()}
-                autoComplete="off"
-                spellCheck={false}
-                autoCorrect="off"
-                autoCapitalize="off"
-                data-form-type="other"
-                autoFocus
-              />
-              <span className="form-hint">
-                Accepts: owner/repo, GitHub HTTPS URL, or SSH URL
-              </span>
+            <div style={{ display: "flex", gap: 8, marginBottom: 16 }}>
+              <button
+                className={`btn ${addMode === "existing" ? "btn-primary" : "btn-secondary"}`}
+                onClick={() => { setAddMode("existing"); setError(""); }}
+                disabled={loading}
+              >
+                Existing Repo
+              </button>
+              <button
+                className={`btn ${addMode === "new" ? "btn-primary" : "btn-secondary"}`}
+                onClick={() => { setAddMode("new"); setError(""); }}
+                disabled={loading}
+              >
+                New GitHub Repo
+              </button>
             </div>
+
+            {addMode === "existing" ? (
+              <div className="form-group">
+                <label>Repository URL</label>
+                <input
+                  type="text"
+                  value={repoUrl}
+                  onChange={(e) => { setRepoUrl(e.target.value); setError(""); }}
+                  placeholder="owner/repo or git@github.com:owner/repo.git"
+                  onKeyDown={(e) => e.key === "Enter" && !loading && handleSubmitAdd()}
+                  autoComplete="off"
+                  spellCheck={false}
+                  autoCorrect="off"
+                  autoCapitalize="off"
+                  data-form-type="other"
+                  autoFocus
+                />
+                <span className="form-hint">
+                  Accepts: owner/repo, GitHub HTTPS URL, or SSH URL
+                </span>
+              </div>
+            ) : (
+              <>
+                <div className="form-group">
+                  <label>New Repository</label>
+                  <input
+                    type="text"
+                    value={newRepoSpec}
+                    onChange={(e) => { setNewRepoSpec(e.target.value); setError(""); }}
+                    placeholder="repo-name or owner/repo"
+                    onKeyDown={(e) => e.key === "Enter" && !loading && handleSubmitAdd()}
+                    autoComplete="off"
+                    spellCheck={false}
+                    autoCorrect="off"
+                    autoCapitalize="off"
+                    data-form-type="other"
+                    autoFocus
+                  />
+                  <span className="form-hint">
+                    Creates the GitHub repo, initializes a local comb, commits README.md, and pushes the branch.
+                  </span>
+                </div>
+                <div className="form-group">
+                  <label>Description</label>
+                  <input
+                    type="text"
+                    value={newRepoDescription}
+                    onChange={(e) => setNewRepoDescription(e.target.value)}
+                    placeholder="Optional"
+                    onKeyDown={(e) => e.key === "Enter" && !loading && handleSubmitAdd()}
+                  />
+                </div>
+                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+                  <div className="form-group">
+                    <label>Initial Comb</label>
+                    <input
+                      type="text"
+                      value={newCombName}
+                      onChange={(e) => { setNewCombName(e.target.value); setError(""); }}
+                      onKeyDown={(e) => e.key === "Enter" && !loading && handleSubmitAdd()}
+                    />
+                  </div>
+                  <div className="form-group">
+                    <label>Branch</label>
+                    <input
+                      type="text"
+                      value={newBranch}
+                      onChange={(e) => { setNewBranch(e.target.value); setError(""); }}
+                      onKeyDown={(e) => e.key === "Enter" && !loading && handleSubmitAdd()}
+                    />
+                  </div>
+                </div>
+                <label className="checkbox-row">
+                  <input
+                    type="checkbox"
+                    checked={newRepoPrivate}
+                    onChange={(e) => setNewRepoPrivate(e.target.checked)}
+                  />
+                  Private repository
+                </label>
+              </>
+            )}
             {error && <div className="error-box">{error}</div>}
             <div style={{ display: "flex", gap: 8 }}>
               <button
                 className="btn btn-primary"
-                onClick={handleAdd}
+                onClick={handleSubmitAdd}
                 disabled={loading}
               >
-                {loading ? "Verifying & adding..." : "Add"}
+                {loading
+                  ? (addMode === "existing" ? "Verifying & adding..." : "Creating repo...")
+                  : (addMode === "existing" ? "Add" : "Create Repo")}
               </button>
               <button
                 className="btn btn-secondary"
-                onClick={() => { setShowAdd(false); setError(""); setRepoUrl(""); }}
+                onClick={() => {
+                  setShowAdd(false);
+                  setError("");
+                  setRepoUrl("");
+                  setNewRepoSpec("");
+                  setNewRepoDescription("");
+                  setNewCombName("main");
+                  setNewBranch("main");
+                }}
               >
                 Cancel
               </button>

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -11,7 +11,9 @@ import { HiveListScreen } from "./HiveListScreen";
 import { SettingsScreen } from "./SettingsScreen";
 import { HelpScreen } from "./HelpScreen";
 import { Toast } from "./Toast";
-import type { HiveInfo, Comb, PaneConfig, CustomButton, CombOperationResult, HiveOperationResult, Nest, HiveState } from "../types";
+import type { HiveInfo, Comb, PaneConfig, CustomButton, CombOperationResult, HiveOperationResult, Nest, HiveState, OpenCodeAttentionEvent, CombAttentionType } from "../types";
+
+const OPENCODE_CMD = "__beehive_opencode__";
 
 // Normalize comb: convert legacy `cloning` to `operation`
 function normalizeComb(comb: Comb): Comb {
@@ -73,8 +75,10 @@ export function MainLayout({ beehiveDir, onReset }: Props) {
   
   // Toast notifications for operation errors
   const [toasts, setToasts] = useState<Array<{ id: string; message: string; type: "error" | "success" }>>([]);
+  const [combAttention, setCombAttention] = useState<Map<string, CombAttentionType>>(new Map());
 
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const activeCombIdRef = useRef<string | null>(null);
   
   const addToast = useCallback((message: string, type: "error" | "success" = "error") => {
     const id = crypto.randomUUID();
@@ -91,6 +95,10 @@ export function MainLayout({ beehiveDir, onReset }: Props) {
 
   const activeHive = hives.find((h) => h.dirName === activeHiveDirName) ?? null;
   const activeRuntime = activeHiveDirName ? hiveRuntimes.get(activeHiveDirName) : undefined;
+
+  useEffect(() => {
+    activeCombIdRef.current = activeRuntime?.activeCombId ?? null;
+  }, [activeRuntime?.activeCombId]);
 
   // Load hives on mount
   useEffect(() => {
@@ -191,6 +199,24 @@ export function MainLayout({ beehiveDir, onReset }: Props) {
     };
   }, [addToast]);
 
+  useEffect(() => {
+    const unlisten = listen<OpenCodeAttentionEvent>("opencode-attention", (event) => {
+      const { attentionKey, status } = event.payload;
+      setCombAttention((prev) => {
+        const next = new Map(prev);
+        if (status === "clear" || activeCombIdRef.current === attentionKey) {
+          next.delete(attentionKey);
+        } else {
+          next.set(attentionKey, status);
+        }
+        return next;
+      });
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
   // Periodically refresh comb branches from git
   useEffect(() => {
     const interval = setInterval(async () => {
@@ -263,6 +289,12 @@ export function MainLayout({ beehiveDir, onReset }: Props) {
 
   async function openComb(comb: Comb) {
     if (!activeHiveDirName) return;
+    setCombAttention((prev) => {
+      if (!prev.has(comb.id)) return prev;
+      const next = new Map(prev);
+      next.delete(comb.id);
+      return next;
+    });
 
     const runtime = getOrCreateRuntime(activeHiveDirName);
 
@@ -334,10 +366,40 @@ export function MainLayout({ beehiveDir, onReset }: Props) {
     [activeHiveDirName, beehiveDir]
   );
 
+  const addOpenCodePane = useCallback(
+    (combId: string) => {
+      if (!activeHiveDirName) return;
+      const hiveDirName = activeHiveDirName;
+      updateRuntime(hiveDirName, (rt) => {
+        const current = rt.panesByComb.get(combId) ?? [];
+        const newPane: PaneConfig = {
+          id: crypto.randomUUID(),
+          type: "opencode",
+          cmd: OPENCODE_CMD,
+        };
+        const updated = [...current, newPane];
+        debounceSavePanes(hiveDirName, combId, updated);
+        const newFocused = new Map(rt.focusedPaneByComb);
+        newFocused.set(combId, newPane.id);
+        return { ...rt, panesByComb: new Map(rt.panesByComb).set(combId, updated), focusedPaneByComb: newFocused };
+      });
+    },
+    [activeHiveDirName, beehiveDir]
+  );
+
   const removePane = useCallback(
     (combId: string, paneId: string) => {
       if (!activeHiveDirName) return;
       const hiveDirName = activeHiveDirName;
+      const removedPane = hiveRuntimes.get(hiveDirName)?.panesByComb.get(combId)?.find((p) => p.id === paneId);
+      if (removedPane?.type === "opencode" || removedPane?.cmd === OPENCODE_CMD) {
+        setCombAttention((prev) => {
+          if (!prev.has(combId)) return prev;
+          const next = new Map(prev);
+          next.delete(combId);
+          return next;
+        });
+      }
       updateRuntime(hiveDirName, (rt) => {
         const current = rt.panesByComb.get(combId) ?? [];
         const updated = current.filter((p) => p.id !== paneId);
@@ -345,7 +407,7 @@ export function MainLayout({ beehiveDir, onReset }: Props) {
         return { ...rt, panesByComb: new Map(rt.panesByComb).set(combId, updated) };
       });
     },
-    [activeHiveDirName, beehiveDir]
+    [activeHiveDirName, beehiveDir, hiveRuntimes]
   );
 
   async function handleDeleteComb(combId: string) {
@@ -668,6 +730,10 @@ export function MainLayout({ beehiveDir, onReset }: Props) {
   }
 
   const currentCombs = activeRuntime?.combs ?? [];
+  const currentDisplayCombs = currentCombs.map((comb) => ({
+    ...comb,
+    attention: combAttention.get(comb.id),
+  }));
   const currentActiveCombId = activeRuntime?.activeCombId ?? null;
 
   return (
@@ -676,7 +742,7 @@ export function MainLayout({ beehiveDir, onReset }: Props) {
         hives={hives}
         activeHive={activeHive}
         nests={activeRuntime?.nests ?? []}
-        combs={currentCombs}
+        combs={currentDisplayCombs}
         activeCombId={currentActiveCombId}
         onSelectHive={(hive) => {
           selectHive(hive);
@@ -709,6 +775,7 @@ export function MainLayout({ beehiveDir, onReset }: Props) {
             isVisible={isVisible}
             focusedPaneId={focusedPaneId}
             onAddPane={(cmd) => addPane(comb.id, cmd)}
+            onAddOpenCodePane={() => addOpenCodePane(comb.id)}
             onRemovePane={(paneId) => removePane(comb.id, paneId)}
             onPaneFocused={(paneId) => handlePaneFocused(comb.id, paneId)}
             onConfigureButtons={() => {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -293,12 +293,19 @@ function SortableCombSection({
         const canInteract = !hasOperation;
         const canCopy = canInteract && !isDeleting;
         const canRename = canInteract && !isDeleting;
+        const attentionLabel = comb.attention === "input"
+          ? "Needs input"
+          : comb.attention === "idle"
+          ? "Ready"
+          : comb.attention === "error"
+          ? "Error"
+          : null;
 
         return (
           <div
             key={comb.id}
             ref={ref}
-            className={`sidebar-comb-item ${comb.id === activeCombId ? "active" : ""} ${hasOperation ? "has-operation" : ""} ${isDeleting ? "deleting" : ""} ${isDragged ? "dragging" : ""}`}
+            className={`sidebar-comb-item ${comb.id === activeCombId ? "active" : ""} ${hasOperation ? "has-operation" : ""} ${isDeleting ? "deleting" : ""} ${isDragged ? "dragging" : ""} ${comb.attention ? `attention-${comb.attention}` : ""}`}
             style={style}
             onPointerDown={(e) => {
               if (canInteract && editingCombId !== comb.id) onPointerDown(e);
@@ -372,7 +379,10 @@ function SortableCombSection({
                   {operationText ? (
                     <span className="sidebar-comb-operation">{operationText}</span>
                   ) : (
-                    <span className="sidebar-comb-branch">{comb.branch}</span>
+                    <span className="sidebar-comb-branch">
+                      {comb.branch}
+                      {attentionLabel && <span className="sidebar-comb-attention">{attentionLabel}</span>}
+                    </span>
                   )}
                 </>
               )}

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -23,13 +23,14 @@ interface TerminalPaneProps {
   cwd: string;
   cmd?: string;
   args?: string[];
+  attentionKey?: string;
   isVisible: boolean;
   shouldFocus?: boolean;
   onFocus?: () => void;
   onExit?: () => void;
 }
 
-export function TerminalPane({ id, cwd, cmd, args, isVisible, shouldFocus, onFocus, onExit }: TerminalPaneProps) {
+export function TerminalPane({ id, cwd, cmd, args, attentionKey, isVisible, shouldFocus, onFocus, onExit }: TerminalPaneProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
@@ -180,6 +181,7 @@ export function TerminalPane({ id, cwd, cmd, args, isVisible, shouldFocus, onFoc
         cwd: initialCwdRef.current,
         cmd: cmd ?? null,
         args: args ?? null,
+        attentionKey: attentionKey ?? null,
         rows: terminal.rows,
         cols: terminal.cols,
       }).catch((err) => {

--- a/src/components/WorkspaceGrid.tsx
+++ b/src/components/WorkspaceGrid.tsx
@@ -1,6 +1,8 @@
 import { TerminalPane } from "./TerminalPane";
 import type { Comb, PaneConfig, CustomButton } from "../types";
 
+const OPENCODE_CMD = "__beehive_opencode__";
+
 interface Props {
   comb: Comb;
   panes: PaneConfig[];
@@ -8,12 +10,13 @@ interface Props {
   isVisible: boolean;
   focusedPaneId: string | null;
   onAddPane: (cmd?: string) => void;
+  onAddOpenCodePane: () => void;
   onRemovePane: (id: string) => void;
   onPaneFocused: (paneId: string) => void;
   onConfigureButtons: () => void;
 }
 
-export function WorkspaceGrid({ comb, panes, customButtons, isVisible, focusedPaneId, onAddPane, onRemovePane, onPaneFocused, onConfigureButtons }: Props) {
+export function WorkspaceGrid({ comb, panes, customButtons, isVisible, focusedPaneId, onAddPane, onAddOpenCodePane, onRemovePane, onPaneFocused, onConfigureButtons }: Props) {
   const cols = panes.length <= 1 ? 1 : panes.length <= 4 ? 2 : 3;
 
   return (
@@ -26,6 +29,9 @@ export function WorkspaceGrid({ comb, panes, customButtons, isVisible, focusedPa
         <div className="workspace-actions">
           <button className="btn btn-sm" onClick={() => onAddPane()}>
             + Terminal
+          </button>
+          <button className="btn btn-sm" onClick={onAddOpenCodePane}>
+            + OpenCode
           </button>
           {customButtons.map((btn, i) => (
             <button key={i} className="btn btn-sm" onClick={() => onAddPane(btn.cmd)}>
@@ -53,7 +59,7 @@ export function WorkspaceGrid({ comb, panes, customButtons, isVisible, focusedPa
             <div className="pane-header">
               <span className="pane-title">
                 <span className="pane-type-badge">
-                  {pane.type === "agent" ? "AGENT" : "TERM"}
+                  {pane.type === "opencode" ? "OCODE" : pane.type === "agent" ? "AGENT" : "TERM"}
                 </span>
               </span>
               <button
@@ -69,6 +75,8 @@ export function WorkspaceGrid({ comb, panes, customButtons, isVisible, focusedPa
                 id={pane.id}
                 cwd={comb.path}
                 cmd={pane.cmd}
+                args={pane.args}
+                attentionKey={pane.type === "opencode" || pane.cmd === OPENCODE_CMD ? comb.id : undefined}
                 isVisible={isVisible}
                 shouldFocus={focusedPaneId === pane.id}
                 onFocus={() => onPaneFocused(pane.id)}

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,10 +26,12 @@ export interface HiveInfo {
 
 export interface PaneConfig {
   id: string;
-  type: "agent" | "terminal";
+  type: "agent" | "terminal" | "opencode";
   cmd?: string;
   args?: string[];
 }
+
+export type CombAttentionType = "input" | "idle" | "error";
 
 // Operation types for concurrent comb operations
 export type CombOperationType = "cloning" | "copying" | "deleting";
@@ -44,6 +46,13 @@ export interface Comb {
   panes: PaneConfig[];
   cloning?: boolean; // deprecated, use operation instead
   operation?: CombOperationType; // current operation in progress
+  attention?: CombAttentionType;
+}
+
+export interface OpenCodeAttentionEvent {
+  attentionKey: string;
+  status: CombAttentionType | "clear";
+  eventType: string;
 }
 
 // Event payload from backend for operation completion


### PR DESCRIPTION
## Summary
This PR adds three related workflow improvements to Beehive:

1. Start a brand-new project from Beehive without manually creating a GitHub repo first.
2. Launch OpenCode as a first-class Beehive-managed agent so Beehive can detect when a comb needs user attention.
3. Restart a stuck TUI comb terminal with `R`.

## Changes

### 1. Fresh hive creation
- Adds a new GUI `+ Add Hive` mode for creating a new GitHub repository instead of linking an existing one.
- The fresh repo flow:
  - accepts `repo-name` or `owner/repo`
  - creates the GitHub repo through `gh repo create`
  - creates the first local comb directory
  - runs `git init`
  - creates the initial branch
  - writes a starter `README.md`
  - makes the initial commit
  - configures `origin`
  - pushes the branch
  - writes normal Beehive hive/comb state so future combs use the existing clone flow
- Adds a minimal TUI path with `A` for creating a new private GitHub repo and initial `main` comb.
- Existing add-hive behavior for already-existing repositories is unchanged.

### 2. OpenCode attention tracking
- Adds a first-class `+ OpenCode` pane in the GUI workspace header.
- Adds TUI shortcut `o` to launch OpenCode for the selected comb.
- Beehive now assigns OpenCode a local port when launching it, then subscribes to OpenCode's `/event` SSE stream.
- The listener watches OpenCode events and marks combs accordingly:
  - `permission.asked` and `question.asked` -> needs input
  - `session.idle` -> ready
  - `session.error` -> error
  - reply/status events -> clear attention state
- GUI combs render attention badges/styling in the sidebar.
- TUI combs render attention markers and labels in the sidebar.
- If OpenCode is launched into an existing TUI terminal, Beehive injects `opencode --hostname 127.0.0.1 --port <port>` into that PTY so it works with existing shell/zellij/tmux flows.
- Direct Beehive-launched OpenCode sessions now return to a login shell after OpenCode exits instead of leaving a dead PTY.

### 3. TUI comb terminal restart
- Changes TUI `R` from manual refresh to restart the selected comb terminal.
- Restart clears stale terminal/OpenCode attention state and reopens the comb terminal.
- Updates the bottom help bar and full help screen to show `R restart`.

## Reviewer Notes
- OpenCode attention tracking is intentionally scoped to OpenCode instances launched by Beehive. If a user manually types `opencode` in a generic terminal without Beehive assigning the port, Beehive cannot reliably subscribe to that OpenCode server.
- OpenCode does not currently expose a generic signal for arbitrary subprocess stdin prompts, so the attention states target OpenCode-level permissions/questions/session events only.
- Fresh hive creation depends on working `gh` authentication and GitHub repo creation permissions.

## Checks
- `source "$HOME/.cargo/env" && cargo check` in `src-tauri`
- `source "$HOME/.cargo/env" && cargo check` in `cli`
- `npx tsc --noEmit`